### PR TITLE
Add haptic feedback for user interactions (#40)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-mobile-development@claude-code-workflows": true
+  }
+}

--- a/app/(tabs)/setup/general.tsx
+++ b/app/(tabs)/setup/general.tsx
@@ -13,6 +13,7 @@ import InputTime from "@/components/ui/InputTime";
 import { useOnboardingStore, Status } from "@/stores/onboarding";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { sanitizePositiveNumber } from "@/utils/validation";
+import { IS_HAPTICS_SUPPORTED } from "@/hooks/useHaptics";
 
 export default function GeneralSettings() {
   const { t } = useTranslation("setup");
@@ -132,23 +133,27 @@ export default function GeneralSettings() {
               value={onboarding.status}
             />
           </View>
-          <View>
-            <ModalPicker
-              label={t("hapticFeedback")}
-              options={[
-                {
-                  label: t("on"),
-                  value: "on",
-                },
-                {
-                  label: t("off"),
-                  value: "off",
-                },
-              ]}
-              onSelect={(value) => setupStore.setHapticsEnabled(value === "on")}
-              value={setupStore.hapticsEnabled ? "on" : "off"}
-            />
-          </View>
+          {IS_HAPTICS_SUPPORTED && (
+            <View>
+              <ModalPicker
+                label={t("hapticFeedback")}
+                options={[
+                  {
+                    label: t("on"),
+                    value: "on",
+                  },
+                  {
+                    label: t("off"),
+                    value: "off",
+                  },
+                ]}
+                onSelect={(value) =>
+                  setupStore.setHapticsEnabled(value === "on")
+                }
+                value={setupStore.hapticsEnabled ? "on" : "off"}
+              />
+            </View>
+          )}
         </ScrollView>
       </TouchableWithoutFeedback>
     </ErrorBoundary>

--- a/app/(tabs)/setup/general.tsx
+++ b/app/(tabs)/setup/general.tsx
@@ -132,6 +132,23 @@ export default function GeneralSettings() {
               value={onboarding.status}
             />
           </View>
+          <View>
+            <ModalPicker
+              label={t("hapticFeedback")}
+              options={[
+                {
+                  label: t("on"),
+                  value: "on",
+                },
+                {
+                  label: t("off"),
+                  value: "off",
+                },
+              ]}
+              onSelect={(value) => setupStore.setHapticsEnabled(value === "on")}
+              value={setupStore.hapticsEnabled ? "on" : "off"}
+            />
+          </View>
         </ScrollView>
       </TouchableWithoutFeedback>
     </ErrorBoundary>

--- a/components/AddWater.tsx
+++ b/components/AddWater.tsx
@@ -13,11 +13,18 @@ import { useCallback, useRef, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import PickerWheel from "@/components/ui/PickerWheel";
 import Modal, { ModalHeader } from "@/components/ui/Modal";
+import { useHaptics } from "@/hooks/useHaptics";
 
 export default function AddWater() {
   const { t } = useTranslation();
   const { addWater } = useWater();
   const { glassCapacity } = useSetupStore();
+  const { impactMedium } = useHaptics();
+
+  const handleAddWater = () => {
+    impactMedium();
+    addWater();
+  };
 
   return (
     <>
@@ -27,7 +34,7 @@ export default function AddWater() {
         }
       >
         <Pressable
-          onPress={addWater}
+          onPress={handleAddWater}
           className={
             "flex-1 active:opacity-50 active:bg-blue-400 transition-all"
           }

--- a/components/RemoveWater.tsx
+++ b/components/RemoveWater.tsx
@@ -2,11 +2,20 @@ import { Pressable, Text } from "react-native";
 import { useWater } from "@/hooks/useWater";
 import { useSetupStore } from "@/stores/setup";
 import { useTranslation } from "react-i18next";
+import { useHaptics } from "@/hooks/useHaptics";
 
 export default function RemoveWater() {
   const { t } = useTranslation();
   const { removeWater, water } = useWater();
   const { glassCapacity } = useSetupStore();
+  const { impactLight } = useHaptics();
+
+  const handleRemoveWater = () => {
+    if (Number(water) > 0) {
+      impactLight();
+      removeWater();
+    }
+  };
 
   const defaultClasses =
     "border-blue-500 border text-blue-500 text-lg px-3 py-3 rounded text-center font-semibold";
@@ -26,7 +35,7 @@ export default function RemoveWater() {
 
   return (
     <Pressable
-      onPress={removeWater}
+      onPress={handleRemoveWater}
       className={`${getVariant() !== "disabled" ? "active:opacity-50" : ""}`}
     >
       <Text className={`${defaultClasses} ${variantStyles[getVariant()]}`}>

--- a/components/RemoveWater.tsx
+++ b/components/RemoveWater.tsx
@@ -11,6 +11,8 @@ export default function RemoveWater() {
   const { impactLight } = useHaptics();
 
   const handleRemoveWater = () => {
+    // Only trigger haptic feedback when removal will actually occur
+    // This check ensures feedback is only given for successful actions
     if (Number(water) > 0) {
       impactLight();
       removeWater();

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,13 +1,27 @@
 import { Pressable, Text } from "react-native";
+import { useHaptics, HapticType } from "@/hooks/useHaptics";
 
 type ButtonProps = {
   text: string;
   onPress?: () => void;
   disabled?: boolean;
+  haptic?: HapticType | boolean;
 };
-export default function Button({ text, onPress, disabled }: ButtonProps) {
+export default function Button({
+  text,
+  onPress,
+  disabled,
+  haptic,
+}: ButtonProps) {
+  const { triggerHaptic } = useHaptics();
+
   const handlePress = () => {
     if (!disabled) {
+      if (haptic) {
+        const hapticType =
+          typeof haptic === "boolean" ? "impactMedium" : haptic;
+        triggerHaptic(hapticType);
+      }
       onPress?.();
     }
   };

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -5,6 +5,12 @@ type ButtonProps = {
   text: string;
   onPress?: () => void;
   disabled?: boolean;
+  /**
+   * Enable haptic feedback on button press.
+   * - `true`: Uses "impactMedium" feedback
+   * - `HapticType`: Uses the specified feedback type (e.g., "impactLight", "notificationSuccess")
+   * - `false` or omitted: No haptic feedback
+   */
   haptic?: HapticType | boolean;
 };
 export default function Button({

--- a/hooks/__tests__/useHaptics.test.ts
+++ b/hooks/__tests__/useHaptics.test.ts
@@ -1,0 +1,210 @@
+import * as Haptics from "expo-haptics";
+import { Platform } from "react-native";
+import { triggerHapticFeedback, HapticType } from "../useHaptics";
+
+// Mock expo-haptics
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  selectionAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: "light",
+    Medium: "medium",
+    Heavy: "heavy",
+  },
+  NotificationFeedbackType: {
+    Success: "success",
+    Warning: "warning",
+    Error: "error",
+  },
+}));
+
+describe("triggerHapticFeedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Platform.OS = "ios";
+  });
+
+  describe("haptic types", () => {
+    it("should trigger impactLight haptic correctly", async () => {
+      await triggerHapticFeedback("impactLight", true);
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Light
+      );
+    });
+
+    it("should trigger impactMedium haptic correctly", async () => {
+      await triggerHapticFeedback("impactMedium", true);
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Medium
+      );
+    });
+
+    it("should trigger impactHeavy haptic correctly", async () => {
+      await triggerHapticFeedback("impactHeavy", true);
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Heavy
+      );
+    });
+
+    it("should trigger notificationSuccess haptic correctly", async () => {
+      await triggerHapticFeedback("notificationSuccess", true);
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+        Haptics.NotificationFeedbackType.Success
+      );
+    });
+
+    it("should trigger notificationWarning haptic correctly", async () => {
+      await triggerHapticFeedback("notificationWarning", true);
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+        Haptics.NotificationFeedbackType.Warning
+      );
+    });
+
+    it("should trigger notificationError haptic correctly", async () => {
+      await triggerHapticFeedback("notificationError", true);
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+        Haptics.NotificationFeedbackType.Error
+      );
+    });
+
+    it("should trigger selection haptic correctly", async () => {
+      await triggerHapticFeedback("selection", true);
+      expect(Haptics.selectionAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe("enabled parameter", () => {
+    it("should trigger haptics when enabled is true", async () => {
+      await triggerHapticFeedback("impactMedium", true);
+      expect(Haptics.impactAsync).toHaveBeenCalled();
+    });
+
+    it("should not trigger haptics when enabled is false", async () => {
+      await triggerHapticFeedback("impactMedium", false);
+      expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    });
+
+    it("should default enabled to true when not provided", async () => {
+      await triggerHapticFeedback("impactLight");
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Light
+      );
+    });
+  });
+
+  describe("platform support", () => {
+    it("should trigger haptics on iOS", async () => {
+      Platform.OS = "ios";
+      await triggerHapticFeedback("impactMedium", true);
+      expect(Haptics.impactAsync).toHaveBeenCalled();
+    });
+
+    it("should trigger haptics on Android", async () => {
+      Platform.OS = "android";
+      await triggerHapticFeedback("impactMedium", true);
+      expect(Haptics.impactAsync).toHaveBeenCalled();
+    });
+
+    it("should not trigger haptics on web", async () => {
+      // Platform check is evaluated at module load time (IS_HAPTICS_SUPPORTED constant)
+      // To properly test web platform, we need to isolate the module
+      jest.isolateModules(() => {
+        Platform.OS = "web";
+        const { triggerHapticFeedback: webTrigger } = require("../useHaptics");
+        webTrigger("impactMedium", true);
+        expect(Haptics.impactAsync).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("should silently fail when haptics throw an error", async () => {
+      (Haptics.impactAsync as jest.Mock).mockRejectedValue(
+        new Error("Haptics error")
+      );
+
+      // Should not throw
+      await expect(
+        triggerHapticFeedback("impactMedium", true)
+      ).resolves.not.toThrow();
+    });
+
+    it("should silently fail for notification haptics errors", async () => {
+      (Haptics.notificationAsync as jest.Mock).mockRejectedValue(
+        new Error("Notification haptics error")
+      );
+
+      await expect(
+        triggerHapticFeedback("notificationSuccess", true)
+      ).resolves.not.toThrow();
+    });
+
+    it("should silently fail for selection haptics errors", async () => {
+      (Haptics.selectionAsync as jest.Mock).mockRejectedValue(
+        new Error("Selection haptics error")
+      );
+
+      await expect(
+        triggerHapticFeedback("selection", true)
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("all haptic types integration", () => {
+    it("should correctly map all haptic types to their Expo counterparts", async () => {
+      const testCases: Array<{
+        type: HapticType;
+        expectedMethod: jest.Mock;
+        expectedArg?: string;
+      }> = [
+        {
+          type: "impactLight",
+          expectedMethod: Haptics.impactAsync as jest.Mock,
+          expectedArg: Haptics.ImpactFeedbackStyle.Light,
+        },
+        {
+          type: "impactMedium",
+          expectedMethod: Haptics.impactAsync as jest.Mock,
+          expectedArg: Haptics.ImpactFeedbackStyle.Medium,
+        },
+        {
+          type: "impactHeavy",
+          expectedMethod: Haptics.impactAsync as jest.Mock,
+          expectedArg: Haptics.ImpactFeedbackStyle.Heavy,
+        },
+        {
+          type: "notificationSuccess",
+          expectedMethod: Haptics.notificationAsync as jest.Mock,
+          expectedArg: Haptics.NotificationFeedbackType.Success,
+        },
+        {
+          type: "notificationWarning",
+          expectedMethod: Haptics.notificationAsync as jest.Mock,
+          expectedArg: Haptics.NotificationFeedbackType.Warning,
+        },
+        {
+          type: "notificationError",
+          expectedMethod: Haptics.notificationAsync as jest.Mock,
+          expectedArg: Haptics.NotificationFeedbackType.Error,
+        },
+        {
+          type: "selection",
+          expectedMethod: Haptics.selectionAsync as jest.Mock,
+        },
+      ];
+
+      for (const testCase of testCases) {
+        jest.clearAllMocks();
+        await triggerHapticFeedback(testCase.type, true);
+
+        expect(testCase.expectedMethod).toHaveBeenCalled();
+        if (testCase.expectedArg) {
+          expect(testCase.expectedMethod).toHaveBeenCalledWith(
+            testCase.expectedArg
+          );
+        }
+      }
+    });
+  });
+});

--- a/hooks/__tests__/useHaptics.test.ts
+++ b/hooks/__tests__/useHaptics.test.ts
@@ -1,6 +1,12 @@
 import * as Haptics from "expo-haptics";
 import { Platform } from "react-native";
-import { triggerHapticFeedback, HapticType } from "../useHaptics";
+import {
+  triggerHapticFeedback,
+  useHaptics,
+  HapticType,
+  IS_HAPTICS_SUPPORTED,
+} from "../useHaptics";
+import { useSetupStore } from "@/stores/setup";
 
 // Mock expo-haptics
 jest.mock("expo-haptics", () => ({
@@ -17,6 +23,16 @@ jest.mock("expo-haptics", () => ({
     Warning: "warning",
     Error: "error",
   },
+}));
+
+// Mock the setup store
+jest.mock("@/stores/setup", () => ({
+  useSetupStore: jest.fn(),
+}));
+
+// Mock error logging
+jest.mock("@/utils/errorLogging", () => ({
+  logWarning: jest.fn(),
 }));
 
 describe("triggerHapticFeedback", () => {
@@ -206,5 +222,279 @@ describe("triggerHapticFeedback", () => {
         }
       }
     });
+  });
+});
+
+describe("useHaptics hook", () => {
+  const mockUseSetupStore = useSetupStore as jest.MockedFunction<
+    typeof useSetupStore
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Platform.OS = "ios";
+    // Default: haptics enabled
+    mockUseSetupStore.mockReturnValue({ hapticsEnabled: true } as ReturnType<
+      typeof useSetupStore
+    >);
+  });
+
+  describe("returned methods", () => {
+    it("should return all expected methods and properties", () => {
+      const result = useHaptics();
+
+      expect(result.triggerHaptic).toBeDefined();
+      expect(typeof result.triggerHaptic).toBe("function");
+
+      expect(result.impactLight).toBeDefined();
+      expect(typeof result.impactLight).toBe("function");
+
+      expect(result.impactMedium).toBeDefined();
+      expect(typeof result.impactMedium).toBe("function");
+
+      expect(result.impactHeavy).toBeDefined();
+      expect(typeof result.impactHeavy).toBe("function");
+
+      expect(result.notificationSuccess).toBeDefined();
+      expect(typeof result.notificationSuccess).toBe("function");
+
+      expect(result.notificationWarning).toBeDefined();
+      expect(typeof result.notificationWarning).toBe("function");
+
+      expect(result.notificationError).toBeDefined();
+      expect(typeof result.notificationError).toBe("function");
+
+      expect(result.selection).toBeDefined();
+      expect(typeof result.selection).toBe("function");
+
+      expect(result.isHapticsSupported).toBeDefined();
+      expect(typeof result.isHapticsSupported).toBe("boolean");
+
+      expect(result.isEnabled).toBeDefined();
+      expect(typeof result.isEnabled).toBe("boolean");
+    });
+
+    it("should return isEnabled as true when haptics are enabled in store", () => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: true } as ReturnType<
+        typeof useSetupStore
+      >);
+      const result = useHaptics();
+      expect(result.isEnabled).toBe(true);
+    });
+
+    it("should return isEnabled as false when haptics are disabled in store", () => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: false } as ReturnType<
+        typeof useSetupStore
+      >);
+      const result = useHaptics();
+      expect(result.isEnabled).toBe(false);
+    });
+
+    it("should return isHapticsSupported correctly based on platform", () => {
+      const result = useHaptics();
+      // Platform is 'ios' in beforeEach, so should be supported
+      expect(result.isHapticsSupported).toBe(IS_HAPTICS_SUPPORTED);
+    });
+  });
+
+  describe("triggerHaptic method", () => {
+    it("should trigger haptic when enabled", async () => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: true } as ReturnType<
+        typeof useSetupStore
+      >);
+      const { triggerHaptic } = useHaptics();
+
+      await triggerHaptic("impactMedium");
+
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Medium
+      );
+    });
+
+    it("should not trigger haptic when disabled in store", async () => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: false } as ReturnType<
+        typeof useSetupStore
+      >);
+      const { triggerHaptic } = useHaptics();
+
+      await triggerHaptic("impactMedium");
+
+      expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    });
+
+    it("should handle all haptic types correctly", async () => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: true } as ReturnType<
+        typeof useSetupStore
+      >);
+      const { triggerHaptic } = useHaptics();
+
+      const hapticTypes: HapticType[] = [
+        "impactLight",
+        "impactMedium",
+        "impactHeavy",
+        "notificationSuccess",
+        "notificationWarning",
+        "notificationError",
+        "selection",
+      ];
+
+      for (const type of hapticTypes) {
+        jest.clearAllMocks();
+        await triggerHaptic(type);
+
+        if (type.startsWith("impact")) {
+          expect(Haptics.impactAsync).toHaveBeenCalled();
+        } else if (type.startsWith("notification")) {
+          expect(Haptics.notificationAsync).toHaveBeenCalled();
+        } else if (type === "selection") {
+          expect(Haptics.selectionAsync).toHaveBeenCalled();
+        }
+      }
+    });
+  });
+
+  describe("convenience methods", () => {
+    beforeEach(() => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: true } as ReturnType<
+        typeof useSetupStore
+      >);
+    });
+
+    it("impactLight should trigger light impact haptic", async () => {
+      const { impactLight } = useHaptics();
+      await impactLight();
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Light
+      );
+    });
+
+    it("impactMedium should trigger medium impact haptic", async () => {
+      const { impactMedium } = useHaptics();
+      await impactMedium();
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Medium
+      );
+    });
+
+    it("impactHeavy should trigger heavy impact haptic", async () => {
+      const { impactHeavy } = useHaptics();
+      await impactHeavy();
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Heavy
+      );
+    });
+
+    it("notificationSuccess should trigger success notification haptic", async () => {
+      const { notificationSuccess } = useHaptics();
+      await notificationSuccess();
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+        Haptics.NotificationFeedbackType.Success
+      );
+    });
+
+    it("notificationWarning should trigger warning notification haptic", async () => {
+      const { notificationWarning } = useHaptics();
+      await notificationWarning();
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+        Haptics.NotificationFeedbackType.Warning
+      );
+    });
+
+    it("notificationError should trigger error notification haptic", async () => {
+      const { notificationError } = useHaptics();
+      await notificationError();
+      expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+        Haptics.NotificationFeedbackType.Error
+      );
+    });
+
+    it("selection should trigger selection haptic", async () => {
+      const { selection } = useHaptics();
+      await selection();
+      expect(Haptics.selectionAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe("convenience methods when disabled", () => {
+    beforeEach(() => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: false } as ReturnType<
+        typeof useSetupStore
+      >);
+    });
+
+    it("should not trigger any haptics when disabled", async () => {
+      const {
+        impactLight,
+        impactMedium,
+        impactHeavy,
+        notificationSuccess,
+        notificationWarning,
+        notificationError,
+        selection,
+      } = useHaptics();
+
+      await impactLight();
+      await impactMedium();
+      await impactHeavy();
+      await notificationSuccess();
+      await notificationWarning();
+      await notificationError();
+      await selection();
+
+      expect(Haptics.impactAsync).not.toHaveBeenCalled();
+      expect(Haptics.notificationAsync).not.toHaveBeenCalled();
+      expect(Haptics.selectionAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling in hook", () => {
+    beforeEach(() => {
+      mockUseSetupStore.mockReturnValue({ hapticsEnabled: true } as ReturnType<
+        typeof useSetupStore
+      >);
+    });
+
+    it("should silently fail when haptics throw an error", async () => {
+      (Haptics.impactAsync as jest.Mock).mockRejectedValue(
+        new Error("Haptics error")
+      );
+
+      const { impactMedium } = useHaptics();
+
+      // Should not throw
+      await expect(impactMedium()).resolves.not.toThrow();
+    });
+
+    it("should silently fail for notification haptics errors", async () => {
+      (Haptics.notificationAsync as jest.Mock).mockRejectedValue(
+        new Error("Notification haptics error")
+      );
+
+      const { notificationSuccess } = useHaptics();
+
+      await expect(notificationSuccess()).resolves.not.toThrow();
+    });
+
+    it("should silently fail for selection haptics errors", async () => {
+      (Haptics.selectionAsync as jest.Mock).mockRejectedValue(
+        new Error("Selection haptics error")
+      );
+
+      const { selection } = useHaptics();
+
+      await expect(selection()).resolves.not.toThrow();
+    });
+  });
+});
+
+describe("IS_HAPTICS_SUPPORTED constant", () => {
+  it("should be exported and be a boolean", () => {
+    expect(typeof IS_HAPTICS_SUPPORTED).toBe("boolean");
+  });
+
+  it("should be true for iOS platform", () => {
+    // The constant is evaluated at module load time
+    // In test environment, Platform.OS is 'ios' by default
+    expect(IS_HAPTICS_SUPPORTED).toBe(true);
   });
 });

--- a/hooks/useHaptics.ts
+++ b/hooks/useHaptics.ts
@@ -1,6 +1,7 @@
 import * as Haptics from "expo-haptics";
 import { Platform } from "react-native";
 import { useSetupStore } from "@/stores/setup";
+import { logWarning } from "@/utils/errorLogging";
 
 export type HapticType =
   | "impactLight"
@@ -12,7 +13,7 @@ export type HapticType =
   | "selection";
 
 /** Whether the current platform supports haptic feedback */
-const IS_HAPTICS_SUPPORTED = Platform.OS === "ios" || Platform.OS === "android";
+export const IS_HAPTICS_SUPPORTED = Platform.OS === "ios" || Platform.OS === "android";
 
 /**
  * Core function that executes the haptic feedback
@@ -67,8 +68,16 @@ export function useHaptics() {
 
     try {
       await executeHaptic(type);
-    } catch {
-      // Silently fail - haptics is not critical functionality
+    } catch (error) {
+      // Silently fail in production - haptics is not critical functionality
+      // Log warning in dev mode for debugging
+      if (__DEV__) {
+        logWarning(`Haptic feedback failed: ${type}`, {
+          operation: "triggerHaptic",
+          component: "useHaptics",
+          data: { type, error: error instanceof Error ? error.message : String(error) },
+        });
+      }
     }
   };
 
@@ -102,7 +111,15 @@ export async function triggerHapticFeedback(
 
   try {
     await executeHaptic(type);
-  } catch {
-    // Silently fail - haptics is not critical functionality
+  } catch (error) {
+    // Silently fail in production - haptics is not critical functionality
+    // Log warning in dev mode for debugging
+    if (__DEV__) {
+      logWarning(`Haptic feedback failed: ${type}`, {
+        operation: "triggerHapticFeedback",
+        component: "useHaptics",
+        data: { type, error: error instanceof Error ? error.message : String(error) },
+      });
+    }
   }
 }

--- a/hooks/useHaptics.ts
+++ b/hooks/useHaptics.ts
@@ -1,0 +1,125 @@
+import * as Haptics from "expo-haptics";
+import { Platform } from "react-native";
+import { useSetupStore } from "@/stores/setup";
+
+export type HapticType =
+  | "impactLight"
+  | "impactMedium"
+  | "impactHeavy"
+  | "notificationSuccess"
+  | "notificationWarning"
+  | "notificationError"
+  | "selection";
+
+/**
+ * Hook for haptic feedback functionality
+ * Provides different types of haptic feedback that can be triggered
+ * Respects user preference for haptic feedback (can be disabled in settings)
+ */
+export function useHaptics() {
+  const { hapticsEnabled } = useSetupStore();
+
+  const isHapticsSupported = Platform.OS === "ios" || Platform.OS === "android";
+
+  const triggerHaptic = async (type: HapticType) => {
+    if (!hapticsEnabled || !isHapticsSupported) {
+      return;
+    }
+
+    try {
+      switch (type) {
+        case "impactLight":
+          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          break;
+        case "impactMedium":
+          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+          break;
+        case "impactHeavy":
+          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+          break;
+        case "notificationSuccess":
+          await Haptics.notificationAsync(
+            Haptics.NotificationFeedbackType.Success
+          );
+          break;
+        case "notificationWarning":
+          await Haptics.notificationAsync(
+            Haptics.NotificationFeedbackType.Warning
+          );
+          break;
+        case "notificationError":
+          await Haptics.notificationAsync(
+            Haptics.NotificationFeedbackType.Error
+          );
+          break;
+        case "selection":
+          await Haptics.selectionAsync();
+          break;
+      }
+    } catch {
+      // Silently fail - haptics is not critical functionality
+    }
+  };
+
+  return {
+    triggerHaptic,
+    impactLight: () => triggerHaptic("impactLight"),
+    impactMedium: () => triggerHaptic("impactMedium"),
+    impactHeavy: () => triggerHaptic("impactHeavy"),
+    notificationSuccess: () => triggerHaptic("notificationSuccess"),
+    notificationWarning: () => triggerHaptic("notificationWarning"),
+    notificationError: () => triggerHaptic("notificationError"),
+    selection: () => triggerHaptic("selection"),
+    isHapticsSupported,
+    isEnabled: hapticsEnabled,
+  };
+}
+
+/**
+ * Standalone function for triggering haptics outside of React components
+ * Used in stores or other non-component contexts
+ * @param type - The type of haptic feedback to trigger
+ * @param enabled - Whether haptics are enabled (should be passed from store)
+ */
+export async function triggerHapticFeedback(
+  type: HapticType,
+  enabled: boolean = true
+) {
+  const isHapticsSupported = Platform.OS === "ios" || Platform.OS === "android";
+
+  if (!enabled || !isHapticsSupported) {
+    return;
+  }
+
+  try {
+    switch (type) {
+      case "impactLight":
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        break;
+      case "impactMedium":
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+        break;
+      case "impactHeavy":
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+        break;
+      case "notificationSuccess":
+        await Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success
+        );
+        break;
+      case "notificationWarning":
+        await Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Warning
+        );
+        break;
+      case "notificationError":
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        break;
+      case "selection":
+        await Haptics.selectionAsync();
+        break;
+    }
+  } catch {
+    // Silently fail - haptics is not critical functionality
+  }
+}

--- a/hooks/useHaptics.ts
+++ b/hooks/useHaptics.ts
@@ -11,51 +11,62 @@ export type HapticType =
   | "notificationError"
   | "selection";
 
+/** Whether the current platform supports haptic feedback */
+const IS_HAPTICS_SUPPORTED = Platform.OS === "ios" || Platform.OS === "android";
+
+/**
+ * Core function that executes the haptic feedback
+ * Extracted to avoid code duplication between hook and standalone function
+ */
+async function executeHaptic(type: HapticType): Promise<void> {
+  switch (type) {
+    case "impactLight":
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      break;
+    case "impactMedium":
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      break;
+    case "impactHeavy":
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+      break;
+    case "notificationSuccess":
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      break;
+    case "notificationWarning":
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+      break;
+    case "notificationError":
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      break;
+    case "selection":
+      await Haptics.selectionAsync();
+      break;
+  }
+}
+
 /**
  * Hook for haptic feedback functionality
  * Provides different types of haptic feedback that can be triggered
  * Respects user preference for haptic feedback (can be disabled in settings)
+ *
+ * @returns Object containing:
+ * - triggerHaptic: Generic function to trigger any haptic type
+ * - impactLight/Medium/Heavy: Convenience methods for impact feedback
+ * - notificationSuccess/Warning/Error: Convenience methods for notification feedback
+ * - selection: Convenience method for selection feedback
+ * - isHapticsSupported: Whether the platform supports haptics
+ * - isEnabled: Current user preference for haptics
  */
 export function useHaptics() {
   const { hapticsEnabled } = useSetupStore();
 
-  const isHapticsSupported = Platform.OS === "ios" || Platform.OS === "android";
-
-  const triggerHaptic = async (type: HapticType) => {
-    if (!hapticsEnabled || !isHapticsSupported) {
+  const triggerHaptic = async (type: HapticType): Promise<void> => {
+    if (!hapticsEnabled || !IS_HAPTICS_SUPPORTED) {
       return;
     }
 
     try {
-      switch (type) {
-        case "impactLight":
-          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          break;
-        case "impactMedium":
-          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-          break;
-        case "impactHeavy":
-          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-          break;
-        case "notificationSuccess":
-          await Haptics.notificationAsync(
-            Haptics.NotificationFeedbackType.Success
-          );
-          break;
-        case "notificationWarning":
-          await Haptics.notificationAsync(
-            Haptics.NotificationFeedbackType.Warning
-          );
-          break;
-        case "notificationError":
-          await Haptics.notificationAsync(
-            Haptics.NotificationFeedbackType.Error
-          );
-          break;
-        case "selection":
-          await Haptics.selectionAsync();
-          break;
-      }
+      await executeHaptic(type);
     } catch {
       // Silently fail - haptics is not critical functionality
     }
@@ -63,14 +74,14 @@ export function useHaptics() {
 
   return {
     triggerHaptic,
-    impactLight: () => triggerHaptic("impactLight"),
-    impactMedium: () => triggerHaptic("impactMedium"),
-    impactHeavy: () => triggerHaptic("impactHeavy"),
-    notificationSuccess: () => triggerHaptic("notificationSuccess"),
-    notificationWarning: () => triggerHaptic("notificationWarning"),
-    notificationError: () => triggerHaptic("notificationError"),
-    selection: () => triggerHaptic("selection"),
-    isHapticsSupported,
+    impactLight: (): Promise<void> => triggerHaptic("impactLight"),
+    impactMedium: (): Promise<void> => triggerHaptic("impactMedium"),
+    impactHeavy: (): Promise<void> => triggerHaptic("impactHeavy"),
+    notificationSuccess: (): Promise<void> => triggerHaptic("notificationSuccess"),
+    notificationWarning: (): Promise<void> => triggerHaptic("notificationWarning"),
+    notificationError: (): Promise<void> => triggerHaptic("notificationError"),
+    selection: (): Promise<void> => triggerHaptic("selection"),
+    isHapticsSupported: IS_HAPTICS_SUPPORTED,
     isEnabled: hapticsEnabled,
   };
 }
@@ -84,41 +95,13 @@ export function useHaptics() {
 export async function triggerHapticFeedback(
   type: HapticType,
   enabled: boolean = true
-) {
-  const isHapticsSupported = Platform.OS === "ios" || Platform.OS === "android";
-
-  if (!enabled || !isHapticsSupported) {
+): Promise<void> {
+  if (!enabled || !IS_HAPTICS_SUPPORTED) {
     return;
   }
 
   try {
-    switch (type) {
-      case "impactLight":
-        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-        break;
-      case "impactMedium":
-        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-        break;
-      case "impactHeavy":
-        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-        break;
-      case "notificationSuccess":
-        await Haptics.notificationAsync(
-          Haptics.NotificationFeedbackType.Success
-        );
-        break;
-      case "notificationWarning":
-        await Haptics.notificationAsync(
-          Haptics.NotificationFeedbackType.Warning
-        );
-        break;
-      case "notificationError":
-        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-        break;
-      case "selection":
-        await Haptics.selectionAsync();
-        break;
-    }
+    await executeHaptic(type);
   } catch {
     // Silently fail - haptics is not critical functionality
   }

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -8,6 +8,7 @@
   "on": "On",
   "off": "Off",
   "enableOnboarding": "Enable onboarding",
+  "hapticFeedback": "Haptic feedback",
   "backupAndSync": "Backup & Sync",
   "exportDataJSON": "Export Data (JSON)",
   "exportDataCSV": "Export Data (CSV)",

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -8,6 +8,7 @@
   "on": "Włączone",
   "off": "Wyłączone",
   "enableOnboarding": "Włącz onboarding",
+  "hapticFeedback": "Sprzężenie zwrotne (wibracje)",
   "backupAndSync": "Kopia zapasowa i synchronizacja",
   "exportDataJSON": "Eksportuj dane (JSON)",
   "exportDataCSV": "Eksportuj dane (CSV)",

--- a/stores/gamification.ts
+++ b/stores/gamification.ts
@@ -247,9 +247,6 @@ export const useGamificationStore = create<GamificationStore>((set, get) => ({
           };
           hasChanges = true;
 
-          // Trigger haptic feedback for achievement unlock
-          triggerHapticFeedback("notificationSuccess", hapticsEnabled);
-
           // Add notification for unlocked achievement
           get().addNotification({
             type: "achievement",
@@ -262,6 +259,9 @@ export const useGamificationStore = create<GamificationStore>((set, get) => ({
       });
 
       if (hasChanges) {
+        // Trigger haptic feedback once for all unlocked achievements
+        // (avoids multiple rapid haptics when unlocking several at once)
+        triggerHapticFeedback("notificationSuccess", hapticsEnabled);
         set({ achievements: updatedAchievements, lastChecked: now });
         await get().updateStorage();
       }

--- a/stores/gamification.ts
+++ b/stores/gamification.ts
@@ -4,6 +4,7 @@ import { useWaterStore } from "./water";
 import { useStatisticsStore } from "./statistics";
 import { useSetupStore } from "./setup";
 import { logError, logWarning } from "@/utils/errorLogging";
+import { triggerHapticFeedback } from "@/hooks/useHaptics";
 
 export type AchievementType =
   | "first_glass"
@@ -233,6 +234,7 @@ export const useGamificationStore = create<GamificationStore>((set, get) => ({
 
       // Unlock achievements and create notifications
       let hasChanges = false;
+      const hapticsEnabled = useSetupStore.getState().hapticsEnabled;
       updatedAchievements.forEach((achievement, index) => {
         if (
           !achievement.isUnlocked &&
@@ -244,6 +246,9 @@ export const useGamificationStore = create<GamificationStore>((set, get) => ({
             unlockedAt: now,
           };
           hasChanges = true;
+
+          // Trigger haptic feedback for achievement unlock
+          triggerHapticFeedback("notificationSuccess", hapticsEnabled);
 
           // Add notification for unlocked achievement
           get().addNotification({

--- a/stores/setup.ts
+++ b/stores/setup.ts
@@ -12,6 +12,7 @@ export enum SetupOptions {
   DAY = "day",
   DATE_FORMAT = "dateFormat",
   LANGUAGE_CODE = "languageCode",
+  HAPTICS_ENABLED = "hapticsEnabled",
 }
 
 type SetupState = {
@@ -23,6 +24,7 @@ type SetupState = {
   };
   [SetupOptions.DATE_FORMAT]: string;
   [SetupOptions.LANGUAGE_CODE]?: string;
+  [SetupOptions.HAPTICS_ENABLED]: boolean;
 };
 
 type SetupActions = {
@@ -31,8 +33,9 @@ type SetupActions = {
   setGlassCapacityTemp: (capacity: string) => void;
   setMinimumWaterTemp: (water: string) => void;
   setLanguageCode: (languageCode: string) => Promise<void>;
+  setHapticsEnabled: (enabled: boolean) => Promise<void>;
   getOptions: () => SetupState;
-  setOption: (option: SetupOptions, value: number | string | {}) => Promise<void>;
+  setOption: (option: SetupOptions, value: number | string | {} | boolean) => Promise<void>;
   reset: () => Promise<void>;
   fetchOrInitData: () => Promise<void>;
   getDayProgress: () => number;
@@ -49,6 +52,7 @@ const initialState: SetupState = {
   },
   dateFormat: DEFAULT_DATE_FORMAT,
   languageCode: Localization.getLocales()[0].languageCode || "en",
+  hapticsEnabled: true,
 };
 
 export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
@@ -88,7 +92,12 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
           if (parsedData.languageCode && typeof parsedData.languageCode === 'string') {
             validatedData.languageCode = parsedData.languageCode;
           }
-          
+
+          // Validate haptics setting (default to true if not set)
+          if (typeof parsedData.hapticsEnabled === 'boolean') {
+            validatedData.hapticsEnabled = parsedData.hapticsEnabled;
+          }
+
           set(validatedData);
         } else {
           logWarning('Invalid setup data structure, reinitializing', {
@@ -127,6 +136,7 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
     day: get().day,
     dateFormat: get()[SetupOptions.DATE_FORMAT],
     languageCode: get()[SetupOptions.LANGUAGE_CODE],
+    hapticsEnabled: get()[SetupOptions.HAPTICS_ENABLED],
   }),
   setGlassCapacity: async (capacity: string) => {
     // Sanitize and persist to storage
@@ -152,7 +162,7 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
       [SetupOptions.MINIMUM_WATER]: water,
     }));
   },
-  setOption: async (option: SetupOptions, value: number | string | {}) => {
+  setOption: async (option: SetupOptions, value: number | string | {} | boolean) => {
     set((state) => ({
       ...state,
       [option]: value,
@@ -170,6 +180,9 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
   },
   setLanguageCode: async (languageCode: string) => {
     await get().setOption(SetupOptions.LANGUAGE_CODE, languageCode);
+  },
+  setHapticsEnabled: async (enabled: boolean) => {
+    await get().setOption(SetupOptions.HAPTICS_ENABLED, enabled);
   },
   reset: async () => {
     set(initialState);


### PR DESCRIPTION
## Summary
- Create reusable `useHaptics` hook with support for different feedback types
- Add haptic feedback when adding/removing water and unlocking achievements
- Add `hapticsEnabled` setting allowing users to toggle haptics

## Changes
- **New:** `hooks/useHaptics.ts` - Reusable haptics hook
- **Modified:** `components/AddWater.tsx` - impactMedium on add
- **Modified:** `components/RemoveWater.tsx` - impactLight on remove
- **Modified:** `stores/gamification.ts` - notificationSuccess on achievement
- **Modified:** `stores/setup.ts` - hapticsEnabled setting
- **Modified:** `components/ui/Button.tsx` - optional haptic prop

## Test plan
- [x] Haptic feedback works on iOS
- [x] Haptic feedback works on Android
- [x] All 70 tests pass
- [x] User can disable haptics in settings

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)