### PR TITLE
Add quick actions for predefined water portions (#44)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -19,6 +19,7 @@ import CardSecond from "@/components/onboarding/CardSecond";
 import CardThird from "@/components/onboarding/CardThird";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import CardStreakAchievements from "@/components/CardStreakAchievements";
+import QuickActions from "@/components/QuickActions";
 
 const duration = 50;
 
@@ -82,6 +83,9 @@ export default function Index() {
             <CardWaterAmount />
           </Animated.View>
           <CardThird />
+          <Animated.View layout={CurvedTransition}>
+            <QuickActions />
+          </Animated.View>
           <Animated.View layout={CurvedTransition} className={"flex-row gap-3"}>
             <View className={"flex-1"}>
               <RemoveWater />

--- a/app/(tabs)/setup/_layout.tsx
+++ b/app/(tabs)/setup/_layout.tsx
@@ -27,6 +27,13 @@ export default function SetupLayout() {
           headerBackTitle: t("back"),
         }}
       />
+      <Stack.Screen
+        name="quick-actions"
+        options={{
+          title: t("quickActions"),
+          headerBackTitle: t("back"),
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(tabs)/setup/index.tsx
+++ b/app/(tabs)/setup/index.tsx
@@ -16,6 +16,12 @@ export default function SettingsMenu() {
       onPress: () => router.push("/(tabs)/setup/general"),
     },
     {
+      id: "quick-actions",
+      title: t("quickActions"),
+      icon: "bolt",
+      onPress: () => router.push("/(tabs)/setup/quick-actions"),
+    },
+    {
       id: "backup",
       title: t("backup"),
       icon: "download",

--- a/app/(tabs)/setup/quick-actions.tsx
+++ b/app/(tabs)/setup/quick-actions.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable, ScrollView, Switch } from "react-native";
+import { View, Text, Pressable, ScrollView, Switch, Alert } from "react-native";
 import { useSetupStore, QuickAction } from "@/stores/setup";
 import { useTranslation } from "react-i18next";
 import Input from "@/components/ui/Input";
@@ -6,6 +6,12 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import { useState } from "react";
 import { sanitizePositiveNumber } from "@/utils/validation";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { logError } from "@/utils/errorLogging";
+import {
+  MAX_QUICK_ACTIONS,
+  MAX_QUICK_ACTION_AMOUNT,
+  DEFAULT_QUICK_ACTION_AMOUNT,
+} from "@/constants/app";
 
 export default function QuickActionsSettings() {
   const { t } = useTranslation("setup");
@@ -13,8 +19,18 @@ export default function QuickActionsSettings() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState<string>("");
 
+  const isAtMaxActions = quickActions.length >= MAX_QUICK_ACTIONS;
+
   const handleToggle = async (id: string, enabled: boolean) => {
-    await updateQuickAction(id, { enabled });
+    try {
+      await updateQuickAction(id, { enabled });
+    } catch (error) {
+      logError(error, {
+        operation: "handleToggle",
+        component: "QuickActionsSettings",
+        data: { id, enabled },
+      });
+    }
   };
 
   const handleStartEdit = (action: QuickAction) => {
@@ -23,11 +39,19 @@ export default function QuickActionsSettings() {
   };
 
   const handleSaveEdit = async (id: string) => {
-    const sanitized = sanitizePositiveNumber(editValue, "250");
-    const amount = parseInt(sanitized, 10);
-    await updateQuickAction(id, { amount });
-    setEditingId(null);
-    setEditValue("");
+    try {
+      const sanitized = sanitizePositiveNumber(editValue, "250");
+      const amount = Math.min(parseInt(sanitized, 10), MAX_QUICK_ACTION_AMOUNT);
+      await updateQuickAction(id, { amount });
+      setEditingId(null);
+      setEditValue("");
+    } catch (error) {
+      logError(error, {
+        operation: "handleSaveEdit",
+        component: "QuickActionsSettings",
+        data: { id, editValue },
+      });
+    }
   };
 
   const handleCancelEdit = () => {
@@ -36,19 +60,48 @@ export default function QuickActionsSettings() {
   };
 
   const handleAddAction = async () => {
-    const newId = `custom-${Date.now()}`;
-    const newAction: QuickAction = {
-      id: newId,
-      amount: 200,
-      labelKey: "quickActionCustom",
-      enabled: true,
-    };
-    await setQuickActions([...quickActions, newAction]);
+    if (isAtMaxActions) return;
+
+    try {
+      const newId = `custom-${Date.now()}`;
+      const newAction: QuickAction = {
+        id: newId,
+        amount: DEFAULT_QUICK_ACTION_AMOUNT,
+        labelKey: "quickActionCustom",
+        enabled: true,
+      };
+      await setQuickActions([...quickActions, newAction]);
+    } catch (error) {
+      logError(error, {
+        operation: "handleAddAction",
+        component: "QuickActionsSettings",
+      });
+    }
   };
 
-  const handleRemoveAction = async (id: string) => {
-    const filtered = quickActions.filter((action) => action.id !== id);
-    await setQuickActions(filtered);
+  const handleRemoveAction = (id: string) => {
+    Alert.alert(t("confirmDelete"), t("confirmDeleteQuickAction"), [
+      {
+        text: t("cancel"),
+        style: "cancel",
+      },
+      {
+        text: t("delete"),
+        style: "destructive",
+        onPress: async () => {
+          try {
+            const filtered = quickActions.filter((action) => action.id !== id);
+            await setQuickActions(filtered);
+          } catch (error) {
+            logError(error, {
+              operation: "handleRemoveAction",
+              component: "QuickActionsSettings",
+              data: { id },
+            });
+          }
+        },
+      },
+    ]);
   };
 
   return (
@@ -76,18 +129,36 @@ export default function QuickActionsSettings() {
                   <Pressable
                     onPress={() => handleSaveEdit(action.id)}
                     className="bg-green-500 p-2 rounded"
+                    accessibilityRole="button"
+                    accessibilityLabel={t("saveQuickActionAccessibilityLabel", {
+                      ns: "translation",
+                    })}
                   >
                     <FontAwesome name="check" size={16} color="#ffffff" />
                   </Pressable>
                   <Pressable
                     onPress={handleCancelEdit}
                     className="bg-gray-400 p-2 rounded"
+                    accessibilityRole="button"
+                    accessibilityLabel={t("cancelEditAccessibilityLabel", {
+                      ns: "translation",
+                    })}
                   >
                     <FontAwesome name="times" size={16} color="#ffffff" />
                   </Pressable>
                 </View>
               ) : (
-                <Pressable onPress={() => handleStartEdit(action)}>
+                <Pressable
+                  onPress={() => handleStartEdit(action)}
+                  accessibilityRole="button"
+                  accessibilityLabel={t("editQuickActionAccessibilityLabel", {
+                    ns: "translation",
+                    amount: action.amount,
+                  })}
+                  accessibilityHint={t("editQuickActionAccessibilityHint", {
+                    ns: "translation",
+                  })}
+                >
                   <Text className="text-lg font-semibold text-gray-900">
                     {action.amount}ml
                   </Text>
@@ -103,6 +174,11 @@ export default function QuickActionsSettings() {
                 <Pressable
                   onPress={() => handleRemoveAction(action.id)}
                   className="p-2"
+                  accessibilityRole="button"
+                  accessibilityLabel={t("deleteQuickActionAccessibilityLabel", {
+                    ns: "translation",
+                    amount: action.amount,
+                  })}
                 >
                   <FontAwesome name="trash" size={18} color="#ef4444" />
                 </Pressable>
@@ -119,7 +195,15 @@ export default function QuickActionsSettings() {
 
         <Pressable
           onPress={handleAddAction}
-          className="bg-blue-500 rounded-lg p-4 flex-row items-center justify-center gap-2 active:opacity-70"
+          disabled={isAtMaxActions}
+          className={`bg-blue-500 rounded-lg p-4 flex-row items-center justify-center gap-2 active:opacity-70 ${
+            isAtMaxActions ? "opacity-50" : ""
+          }`}
+          accessibilityRole="button"
+          accessibilityLabel={t("addQuickActionAccessibilityLabel", {
+            ns: "translation",
+          })}
+          accessibilityState={{ disabled: isAtMaxActions }}
         >
           <FontAwesome name="plus" size={16} color="#ffffff" />
           <Text className="text-white font-semibold">

--- a/app/(tabs)/setup/quick-actions.tsx
+++ b/app/(tabs)/setup/quick-actions.tsx
@@ -1,0 +1,132 @@
+import { View, Text, Pressable, ScrollView, Switch } from "react-native";
+import { useSetupStore, QuickAction } from "@/stores/setup";
+import { useTranslation } from "react-i18next";
+import Input from "@/components/ui/Input";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import { useState } from "react";
+import { sanitizePositiveNumber } from "@/utils/validation";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+
+export default function QuickActionsSettings() {
+  const { t } = useTranslation("setup");
+  const { quickActions, updateQuickAction, setQuickActions } = useSetupStore();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState<string>("");
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    await updateQuickAction(id, { enabled });
+  };
+
+  const handleStartEdit = (action: QuickAction) => {
+    setEditingId(action.id);
+    setEditValue(action.amount.toString());
+  };
+
+  const handleSaveEdit = async (id: string) => {
+    const sanitized = sanitizePositiveNumber(editValue, "250");
+    const amount = parseInt(sanitized, 10);
+    await updateQuickAction(id, { amount });
+    setEditingId(null);
+    setEditValue("");
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditValue("");
+  };
+
+  const handleAddAction = async () => {
+    const newId = `custom-${Date.now()}`;
+    const newAction: QuickAction = {
+      id: newId,
+      amount: 200,
+      labelKey: "quickActionCustom",
+      enabled: true,
+    };
+    await setQuickActions([...quickActions, newAction]);
+  };
+
+  const handleRemoveAction = async (id: string) => {
+    const filtered = quickActions.filter((action) => action.id !== id);
+    await setQuickActions(filtered);
+  };
+
+  return (
+    <ErrorBoundary componentName="Quick Actions Settings">
+      <ScrollView contentContainerClassName="p-5 gap-4">
+        <Text className="text-gray-600 text-sm mb-2">
+          {t("quickActionsDescription")}
+        </Text>
+
+        {quickActions.map((action) => (
+          <View
+            key={action.id}
+            className="bg-gray-50 rounded-lg p-4 flex-row items-center justify-between"
+          >
+            <View className="flex-1">
+              {editingId === action.id ? (
+                <View className="flex-row items-center gap-2">
+                  <Input
+                    value={editValue}
+                    onChangeText={setEditValue}
+                    keyboardType="numeric"
+                    placeholder="0"
+                    className="flex-1"
+                  />
+                  <Pressable
+                    onPress={() => handleSaveEdit(action.id)}
+                    className="bg-green-500 p-2 rounded"
+                  >
+                    <FontAwesome name="check" size={16} color="#ffffff" />
+                  </Pressable>
+                  <Pressable
+                    onPress={handleCancelEdit}
+                    className="bg-gray-400 p-2 rounded"
+                  >
+                    <FontAwesome name="times" size={16} color="#ffffff" />
+                  </Pressable>
+                </View>
+              ) : (
+                <Pressable onPress={() => handleStartEdit(action)}>
+                  <Text className="text-lg font-semibold text-gray-900">
+                    {action.amount}ml
+                  </Text>
+                  <Text className="text-gray-500 text-sm">
+                    {t(action.labelKey, { ns: "translation" })}
+                  </Text>
+                </Pressable>
+              )}
+            </View>
+
+            <View className="flex-row items-center gap-3">
+              {action.id.startsWith("custom-") && (
+                <Pressable
+                  onPress={() => handleRemoveAction(action.id)}
+                  className="p-2"
+                >
+                  <FontAwesome name="trash" size={18} color="#ef4444" />
+                </Pressable>
+              )}
+              <Switch
+                value={action.enabled}
+                onValueChange={(value) => handleToggle(action.id, value)}
+                trackColor={{ false: "#d1d5db", true: "#3b82f6" }}
+                thumbColor={action.enabled ? "#ffffff" : "#f4f4f5"}
+              />
+            </View>
+          </View>
+        ))}
+
+        <Pressable
+          onPress={handleAddAction}
+          className="bg-blue-500 rounded-lg p-4 flex-row items-center justify-center gap-2 active:opacity-70"
+        >
+          <FontAwesome name="plus" size={16} color="#ffffff" />
+          <Text className="text-white font-semibold">
+            {t("addQuickAction")}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -1,0 +1,63 @@
+import { View, Text, Pressable } from "react-native";
+import { useSetupStore } from "@/stores/setup";
+import { useWaterStore } from "@/stores/water";
+import { useGamificationStore } from "@/stores/gamification";
+import { useTranslation } from "react-i18next";
+import * as Haptics from "expo-haptics";
+import { logError } from "@/utils/errorLogging";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+
+export default function QuickActions() {
+  const { t } = useTranslation();
+  const { quickActions } = useSetupStore();
+  const waterStore = useWaterStore();
+  const gamificationStore = useGamificationStore();
+
+  const enabledActions = quickActions.filter((action) => action.enabled);
+
+  const handleQuickAction = async (amount: number) => {
+    try {
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      const currentWater = waterStore.getTodayWater();
+      const newCurrentWater = Number(currentWater) + amount;
+      await waterStore.setTodayWater(newCurrentWater.toString());
+      gamificationStore.checkAndUnlockAchievements();
+    } catch (error) {
+      logError(error, {
+        operation: "handleQuickAction",
+        component: "QuickActions",
+      });
+    }
+  };
+
+  if (enabledActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <View className="bg-white rounded-lg p-4 border border-gray-200">
+      <Text className="text-sm text-gray-600 mb-3 font-medium">
+        {t("quickActions")}
+      </Text>
+      <View className="flex-row gap-2">
+        {enabledActions.map((action) => (
+          <Pressable
+            key={action.id}
+            onPress={() => handleQuickAction(action.amount)}
+            className="flex-1 bg-blue-500 rounded-lg p-3 active:opacity-70 active:bg-blue-600"
+          >
+            <View className="items-center">
+              <FontAwesome name="plus-circle" size={20} color="#ffffff" />
+              <Text className="text-white font-bold text-base mt-1">
+                {action.amount}ml
+              </Text>
+              <Text className="text-blue-100 text-xs">
+                {t(action.labelKey)}
+              </Text>
+            </View>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -3,21 +3,26 @@ import { useSetupStore } from "@/stores/setup";
 import { useWaterStore } from "@/stores/water";
 import { useGamificationStore } from "@/stores/gamification";
 import { useTranslation } from "react-i18next";
-import * as Haptics from "expo-haptics";
+import { useHaptics } from "@/hooks/useHaptics";
 import { logError } from "@/utils/errorLogging";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { useMemo } from "react";
 
 export default function QuickActions() {
   const { t } = useTranslation();
   const { quickActions } = useSetupStore();
   const waterStore = useWaterStore();
   const gamificationStore = useGamificationStore();
+  const { impactMedium } = useHaptics();
 
-  const enabledActions = quickActions.filter((action) => action.enabled);
+  const enabledActions = useMemo(
+    () => quickActions.filter((action) => action.enabled),
+    [quickActions],
+  );
 
   const handleQuickAction = async (amount: number) => {
     try {
-      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      impactMedium();
       const currentWater = waterStore.getTodayWater();
       const newCurrentWater = Number(currentWater) + amount;
       await waterStore.setTodayWater(newCurrentWater.toString());
@@ -45,6 +50,14 @@ export default function QuickActions() {
             key={action.id}
             onPress={() => handleQuickAction(action.amount)}
             className="flex-1 bg-blue-500 rounded-lg p-3 active:opacity-70 active:bg-blue-600"
+            accessibilityRole="button"
+            accessibilityLabel={t("quickActionAccessibilityLabel", {
+              amount: action.amount,
+              label: t(action.labelKey),
+            })}
+            accessibilityHint={t("quickActionAccessibilityHint", {
+              amount: action.amount,
+            })}
           >
             <View className="items-center">
               <FontAwesome name="plus-circle" size={20} color="#ffffff" />

--- a/constants/app.ts
+++ b/constants/app.ts
@@ -22,6 +22,11 @@ export type PickerOption = {
 // Backup settings
 export const AUTO_BACKUP_RETENTION_DAYS = 7;
 
+// Quick Actions settings
+export const MAX_QUICK_ACTIONS = 6;
+export const MAX_QUICK_ACTION_AMOUNT = 5000;
+export const DEFAULT_QUICK_ACTION_AMOUNT = 200;
+
 /**
  * Generates an array of glass capacity options for the picker.
  * Options range from MIN_GLASS_CAPACITY to MAX_GLASS_CAPACITY with GLASS_STEP increments.

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -22,5 +22,9 @@
   "back": "Back",
   "quickActions": "Quick Actions",
   "quickActionsDescription": "Configure quick action buttons for adding water with predefined amounts.",
-  "addQuickAction": "Add Quick Action"
+  "addQuickAction": "Add Quick Action",
+  "confirmDelete": "Confirm Delete",
+  "confirmDeleteQuickAction": "Are you sure you want to delete this quick action?",
+  "cancel": "Cancel",
+  "delete": "Delete"
 }

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -19,5 +19,8 @@
   "setup": "Settings",
   "general": "General",
   "backup": "Backup",
-  "back": "Back"
+  "back": "Back",
+  "quickActions": "Quick Actions",
+  "quickActionsDescription": "Configure quick action buttons for adding water with predefined amounts.",
+  "addQuickAction": "Add Quick Action"
 }

--- a/i18n/en/translation.json
+++ b/i18n/en/translation.json
@@ -50,5 +50,13 @@
   "quickActionGlass": "Glass",
   "quickActionBottle": "Bottle",
   "quickActionCan": "Can",
-  "quickActionCustom": "Custom"
+  "quickActionCustom": "Custom",
+  "quickActionAccessibilityLabel": "Add {{amount}} milliliters, {{label}}",
+  "quickActionAccessibilityHint": "Double tap to add {{amount}} milliliters of water",
+  "addQuickActionAccessibilityLabel": "Add new quick action",
+  "editQuickActionAccessibilityLabel": "Quick action {{amount}} milliliters",
+  "editQuickActionAccessibilityHint": "Double tap to edit the amount",
+  "deleteQuickActionAccessibilityLabel": "Delete quick action {{amount}} milliliters",
+  "saveQuickActionAccessibilityLabel": "Save changes",
+  "cancelEditAccessibilityLabel": "Cancel editing"
 }

--- a/i18n/en/translation.json
+++ b/i18n/en/translation.json
@@ -45,5 +45,10 @@
   "trendStable": "Stable",
   "advancedReports": "Advanced Reports",
   "monthlyReport": "Monthly Report",
-  "weeklyReport": "Weekly Report"
+  "weeklyReport": "Weekly Report",
+  "quickActions": "Quick Actions",
+  "quickActionGlass": "Glass",
+  "quickActionBottle": "Bottle",
+  "quickActionCan": "Can",
+  "quickActionCustom": "Custom"
 }

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -21,6 +21,10 @@
   "backup": "Kopia zapasowa",
   "back": "Wstecz",
   "quickActions": "Szybkie akcje",
-  "quickActionsDescription": "Skonfiguruj przyciski szybkich akcji do dodawania wody z predefiniowanymi ilosciami.",
-  "addQuickAction": "Dodaj szybka akcje"
+  "quickActionsDescription": "Skonfiguruj przyciski szybkich akcji do dodawania wody z predefiniowanymi ilościami.",
+  "addQuickAction": "Dodaj szybką akcję",
+  "confirmDelete": "Potwierdź usunięcie",
+  "confirmDeleteQuickAction": "Czy na pewno chcesz usunąć tę szybką akcję?",
+  "cancel": "Anuluj",
+  "delete": "Usuń"
 }

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -19,5 +19,8 @@
   "setup": "Ustawienia",
   "general": "Ogólne",
   "backup": "Kopia zapasowa",
-  "back": "Wstecz"
+  "back": "Wstecz",
+  "quickActions": "Szybkie akcje",
+  "quickActionsDescription": "Skonfiguruj przyciski szybkich akcji do dodawania wody z predefiniowanymi ilosciami.",
+  "addQuickAction": "Dodaj szybka akcje"
 }

--- a/i18n/pl/translation.json
+++ b/i18n/pl/translation.json
@@ -50,5 +50,13 @@
   "quickActionGlass": "Szklanka",
   "quickActionBottle": "Butelka",
   "quickActionCan": "Puszka",
-  "quickActionCustom": "Niestandardowa"
+  "quickActionCustom": "Niestandardowa",
+  "quickActionAccessibilityLabel": "Dodaj {{amount}} mililitrów, {{label}}",
+  "quickActionAccessibilityHint": "Dotknij dwukrotnie, aby dodać {{amount}} mililitrów wody",
+  "addQuickActionAccessibilityLabel": "Dodaj nową szybką akcję",
+  "editQuickActionAccessibilityLabel": "Szybka akcja {{amount}} mililitrów",
+  "editQuickActionAccessibilityHint": "Dotknij dwukrotnie, aby edytować ilość",
+  "deleteQuickActionAccessibilityLabel": "Usuń szybką akcję {{amount}} mililitrów",
+  "saveQuickActionAccessibilityLabel": "Zapisz zmiany",
+  "cancelEditAccessibilityLabel": "Anuluj edycję"
 }

--- a/i18n/pl/translation.json
+++ b/i18n/pl/translation.json
@@ -45,5 +45,10 @@
   "trendStable": "Stabilny",
   "advancedReports": "Zaawansowane raporty",
   "monthlyReport": "Raport miesięczny",
-  "weeklyReport": "Raport tygodniowy"
+  "weeklyReport": "Raport tygodniowy",
+  "quickActions": "Szybkie akcje",
+  "quickActionGlass": "Szklanka",
+  "quickActionBottle": "Butelka",
+  "quickActionCan": "Puszka",
+  "quickActionCustom": "Niestandardowa"
 }

--- a/stores/setup.ts
+++ b/stores/setup.ts
@@ -14,7 +14,21 @@ export enum SetupOptions {
   DATE_FORMAT = "dateFormat",
   LANGUAGE_CODE = "languageCode",
   HAPTICS_ENABLED = "hapticsEnabled",
+  QUICK_ACTIONS = "quickActions",
 }
+
+export type QuickAction = {
+  id: string;
+  amount: number;
+  labelKey: string;
+  enabled: boolean;
+};
+
+export const DEFAULT_QUICK_ACTIONS: QuickAction[] = [
+  { id: "glass", amount: 250, labelKey: "quickActionGlass", enabled: true },
+  { id: "bottle", amount: 500, labelKey: "quickActionBottle", enabled: true },
+  { id: "can", amount: 330, labelKey: "quickActionCan", enabled: true },
+];
 
 type SetupState = {
   [SetupOptions.GLASS_CAPACITY]: string;
@@ -26,6 +40,7 @@ type SetupState = {
   [SetupOptions.DATE_FORMAT]: string;
   [SetupOptions.LANGUAGE_CODE]?: string;
   [SetupOptions.HAPTICS_ENABLED]: boolean;
+  [SetupOptions.QUICK_ACTIONS]: QuickAction[];
 };
 
 type SetupActions = {
@@ -36,10 +51,12 @@ type SetupActions = {
   setLanguageCode: (languageCode: string) => Promise<void>;
   setHapticsEnabled: (enabled: boolean) => Promise<void>;
   getOptions: () => SetupState;
-  setOption: (option: SetupOptions, value: number | string | {} | boolean) => Promise<void>;
+  setOption: (option: SetupOptions, value: number | string | {} | boolean | QuickAction[]) => Promise<void>;
   reset: () => Promise<void>;
   fetchOrInitData: () => Promise<void>;
   getDayProgress: () => number;
+  setQuickActions: (quickActions: QuickAction[]) => Promise<void>;
+  updateQuickAction: (id: string, updates: Partial<QuickAction>) => Promise<void>;
 };
 
 const storageKey = "setupData";
@@ -54,6 +71,7 @@ const initialState: SetupState = {
   dateFormat: DEFAULT_DATE_FORMAT,
   languageCode: Localization.getLocales()[0].languageCode || "en",
   hapticsEnabled: true,
+  quickActions: DEFAULT_QUICK_ACTIONS,
 };
 
 export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
@@ -99,6 +117,22 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
             validatedData.hapticsEnabled = parsedData.hapticsEnabled;
           }
 
+          // Validate quick actions
+          if (Array.isArray(parsedData.quickActions)) {
+            const validQuickActions = parsedData.quickActions.filter(
+              (action: any) =>
+                typeof action === 'object' &&
+                action !== null &&
+                typeof action.id === 'string' &&
+                typeof action.amount === 'number' &&
+                typeof action.labelKey === 'string' &&
+                typeof action.enabled === 'boolean'
+            );
+            if (validQuickActions.length > 0) {
+              validatedData.quickActions = validQuickActions;
+            }
+          }
+
           set(validatedData);
         } else {
           logWarning('Invalid setup data structure, reinitializing', {
@@ -138,6 +172,7 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
     dateFormat: get()[SetupOptions.DATE_FORMAT],
     languageCode: get()[SetupOptions.LANGUAGE_CODE],
     hapticsEnabled: get()[SetupOptions.HAPTICS_ENABLED],
+    quickActions: get()[SetupOptions.QUICK_ACTIONS],
   }),
   setGlassCapacity: async (capacity: string) => {
     // Sanitize and persist to storage
@@ -163,7 +198,7 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
       [SetupOptions.MINIMUM_WATER]: water,
     }));
   },
-  setOption: async (option: SetupOptions, value: number | string | {} | boolean) => {
+  setOption: async (option: SetupOptions, value: number | string | {} | boolean | QuickAction[]) => {
     set((state) => ({
       ...state,
       [option]: value,
@@ -263,5 +298,15 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
       });
       return 0;
     }
+  },
+  setQuickActions: async (quickActions: QuickAction[]) => {
+    await get().setOption(SetupOptions.QUICK_ACTIONS, quickActions);
+  },
+  updateQuickAction: async (id: string, updates: Partial<QuickAction>) => {
+    const currentActions = get()[SetupOptions.QUICK_ACTIONS];
+    const updatedActions = currentActions.map((action) =>
+      action.id === id ? { ...action, ...updates } : action
+    );
+    await get().setQuickActions(updatedActions);
   },
 }));

--- a/stores/setup.ts
+++ b/stores/setup.ts
@@ -5,7 +5,7 @@ import { DEFAULT_DATE_FORMAT } from "@/config/date";
 import * as Localization from "expo-localization";
 import { sanitizePositiveNumber, isValidTimeFormat } from "@/utils/validation";
 import { logError, logWarning } from "@/utils/errorLogging";
-import { DEFAULT_DAILY_GOAL, DEFAULT_GLASS_CAPACITY } from "@/constants/app";
+import { DEFAULT_DAILY_GOAL, DEFAULT_GLASS_CAPACITY, MAX_QUICK_ACTION_AMOUNT } from "@/constants/app";
 
 export enum SetupOptions {
   GLASS_CAPACITY = "glassCapacity",
@@ -17,10 +17,16 @@ export enum SetupOptions {
   QUICK_ACTIONS = "quickActions",
 }
 
+export type QuickActionLabelKey =
+  | "quickActionGlass"
+  | "quickActionBottle"
+  | "quickActionCan"
+  | "quickActionCustom";
+
 export type QuickAction = {
   id: string;
   amount: number;
-  labelKey: string;
+  labelKey: QuickActionLabelKey;
   enabled: boolean;
 };
 
@@ -119,15 +125,27 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
 
           // Validate quick actions
           if (Array.isArray(parsedData.quickActions)) {
-            const validQuickActions = parsedData.quickActions.filter(
-              (action: any) =>
-                typeof action === 'object' &&
-                action !== null &&
-                typeof action.id === 'string' &&
-                typeof action.amount === 'number' &&
-                typeof action.labelKey === 'string' &&
-                typeof action.enabled === 'boolean'
-            );
+            const validLabelKeys: QuickActionLabelKey[] = [
+              "quickActionGlass",
+              "quickActionBottle",
+              "quickActionCan",
+              "quickActionCustom",
+            ];
+            const validQuickActions = parsedData.quickActions
+              .filter(
+                (action: any) =>
+                  typeof action === 'object' &&
+                  action !== null &&
+                  typeof action.id === 'string' &&
+                  typeof action.amount === 'number' &&
+                  typeof action.labelKey === 'string' &&
+                  validLabelKeys.includes(action.labelKey) &&
+                  typeof action.enabled === 'boolean'
+              )
+              .map((action: QuickAction) => ({
+                ...action,
+                amount: Math.min(action.amount, MAX_QUICK_ACTION_AMOUNT),
+              }));
             if (validQuickActions.length > 0) {
               validatedData.quickActions = validQuickActions;
             }


### PR DESCRIPTION
## Summary
- Add quick action buttons on home screen for adding water with predefined amounts
- Allow users to customize quick actions in settings

## Default Quick Actions
- 250ml - Glass (Szklanka)
- 500ml - Bottle (Butelka)
- 330ml - Can (Puszka)

## Changes
- **New:** `components/QuickActions.tsx` - Quick action buttons component
- **New:** `app/(tabs)/setup/quick-actions.tsx` - Settings screen for customization
- **Modified:** `stores/setup.ts` - QuickAction type and store methods
- **Modified:** `app/(tabs)/index.tsx` - Add QuickActions to home screen
- **Modified:** `app/(tabs)/setup/_layout.tsx` & `index.tsx` - Navigation
- **Modified:** i18n files - EN/PL translations

## Test plan
- [x] 3 predefined quick actions on home screen
- [x] Personalization in settings (enable/disable, edit amount, add custom)
- [x] Haptic feedback when used
- [x] EN/PL translations
- [x] All 70 tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)