### PR TITLE
feat: Add water drinking reminder notifications (#45)

### DIFF
--- a/__tests__/stores/notifications.test.ts
+++ b/__tests__/stores/notifications.test.ts
@@ -1,0 +1,543 @@
+import { useNotificationsStore } from "@/stores/notifications";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  NOTIFICATIONS_STORAGE_KEY,
+  DEFAULT_REMINDER_INTERVAL,
+  DEFAULT_MAX_NOTIFICATIONS,
+} from "@/constants/notifications";
+
+// Mock notification service
+jest.mock("@/services/notificationService", () => ({
+  setupNotificationChannel: jest.fn().mockResolvedValue(undefined),
+  getPermissionStatus: jest.fn().mockResolvedValue("undetermined"),
+  requestPermissions: jest.fn().mockResolvedValue("granted"),
+  scheduleSmartNotifications: jest
+    .fn()
+    .mockResolvedValue({ ids: [], count: 0 }),
+  cancelAllNotifications: jest.fn().mockResolvedValue(undefined),
+  getScheduledNotifications: jest.fn().mockResolvedValue([]),
+  getNotificationContent: jest
+    .fn()
+    .mockReturnValue({ title: "Test", body: "Test body" }),
+  scheduleNotifications: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("@/utils/errorLogging", () => ({
+  logError: jest.fn(),
+  logWarning: jest.fn(),
+}));
+
+// Import mocked modules for assertions
+import {
+  setupNotificationChannel,
+  getPermissionStatus,
+  scheduleSmartNotifications,
+  cancelAllNotifications,
+  getScheduledNotifications,
+  getNotificationContent,
+} from "@/services/notificationService";
+import { logError, logWarning } from "@/utils/errorLogging";
+
+const initialState = {
+  enabled: false,
+  intervalMinutes: DEFAULT_REMINDER_INTERVAL,
+  permissionStatus: "undetermined",
+  lastScheduledTime: null,
+  lastDrinkTimestamp: null,
+  notificationsSinceLastDrink: 0,
+  maxNotifications: DEFAULT_MAX_NOTIFICATIONS,
+  scheduledCount: 0,
+};
+
+describe("NotificationsStore", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+    // Reset store state to initial
+    await useNotificationsStore.getState().reset();
+
+    // Clear mocks again after reset (since reset calls cancelAll + setItem)
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchOrInitData
+  // ---------------------------------------------------------------------------
+  describe("fetchOrInitData", () => {
+    it("should set defaults when no data is stored", async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      const state = useNotificationsStore.getState();
+      expect(state.enabled).toBe(false);
+      expect(state.intervalMinutes).toBe(DEFAULT_REMINDER_INTERVAL);
+      expect(state.permissionStatus).toBe("undetermined");
+      expect(state.lastScheduledTime).toBeNull();
+      expect(state.lastDrinkTimestamp).toBeNull();
+      expect(state.notificationsSinceLastDrink).toBe(0);
+      expect(state.maxNotifications).toBe(DEFAULT_MAX_NOTIFICATIONS);
+      expect(state.scheduledCount).toBe(0);
+    });
+
+    it("should persist initial state when no data is stored", async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        NOTIFICATIONS_STORAGE_KEY,
+        expect.any(String)
+      );
+    });
+
+    it("should setup notification channel on init", async () => {
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      expect(setupNotificationChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it("should check permission status on init", async () => {
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      expect(getPermissionStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it("should load persisted valid data correctly", async () => {
+      const persistedData = {
+        enabled: true,
+        intervalMinutes: 60,
+        lastScheduledTime: "2026-01-28T10:00:00.000Z",
+        lastDrinkTimestamp: "2026-01-28T09:30:00.000Z",
+        notificationsSinceLastDrink: 2,
+        maxNotifications: 1,
+        scheduledCount: 5,
+      };
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(persistedData)
+      );
+      (getPermissionStatus as jest.Mock).mockResolvedValue("granted");
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      const state = useNotificationsStore.getState();
+      expect(state.enabled).toBe(true);
+      expect(state.intervalMinutes).toBe(60);
+      expect(state.lastScheduledTime).toBe("2026-01-28T10:00:00.000Z");
+      expect(state.lastDrinkTimestamp).toBe("2026-01-28T09:30:00.000Z");
+      expect(state.notificationsSinceLastDrink).toBe(2);
+      expect(state.maxNotifications).toBe(1);
+      expect(state.scheduledCount).toBe(5);
+      // permissionStatus comes from OS check, not storage
+      expect(state.permissionStatus).toBe("granted");
+    });
+
+    it("should fall back to defaults for invalid data (non-object)", async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify("not-an-object")
+      );
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      const state = useNotificationsStore.getState();
+      expect(state.enabled).toBe(false);
+      expect(state.intervalMinutes).toBe(DEFAULT_REMINDER_INTERVAL);
+      expect(state.notificationsSinceLastDrink).toBe(0);
+      expect(logWarning).toHaveBeenCalledWith(
+        "Invalid notifications data structure, reinitializing",
+        expect.objectContaining({
+          operation: "fetchOrInitData",
+          component: "NotificationsStore",
+        })
+      );
+    });
+
+    it("should fall back to defaults for invalid field values", async () => {
+      const invalidData = {
+        enabled: "yes", // should be boolean
+        intervalMinutes: 45, // not a valid interval (60, 120, 180)
+        notificationsSinceLastDrink: -5, // negative
+        maxNotifications: 99, // not in MAX_NOTIFICATION_OPTIONS
+        scheduledCount: -1, // negative
+      };
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(invalidData)
+      );
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      const state = useNotificationsStore.getState();
+      expect(state.enabled).toBe(false);
+      expect(state.intervalMinutes).toBe(DEFAULT_REMINDER_INTERVAL);
+      expect(state.notificationsSinceLastDrink).toBe(0);
+      expect(state.maxNotifications).toBe(DEFAULT_MAX_NOTIFICATIONS);
+      expect(state.scheduledCount).toBe(0);
+    });
+
+    it("should handle backward compatibility - missing new fields use defaults", async () => {
+      // Simulates data saved by an older version that did not have
+      // maxNotifications, scheduledCount, lastDrinkTimestamp, or
+      // notificationsSinceLastDrink
+      const oldVersionData = {
+        enabled: true,
+        intervalMinutes: 180,
+        lastScheduledTime: "2026-01-20T08:00:00.000Z",
+      };
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(oldVersionData)
+      );
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      const state = useNotificationsStore.getState();
+      // Persisted fields are loaded
+      expect(state.enabled).toBe(true);
+      expect(state.intervalMinutes).toBe(180);
+      expect(state.lastScheduledTime).toBe("2026-01-20T08:00:00.000Z");
+      // Missing fields fall back to defaults
+      expect(state.lastDrinkTimestamp).toBeNull();
+      expect(state.notificationsSinceLastDrink).toBe(0);
+      expect(state.maxNotifications).toBe(DEFAULT_MAX_NOTIFICATIONS);
+      expect(state.scheduledCount).toBe(0);
+    });
+
+    it("should fall back to defaults and log error on JSON parse failure", async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        "{{invalid-json}}"
+      );
+
+      await useNotificationsStore.getState().fetchOrInitData();
+
+      const state = useNotificationsStore.getState();
+      expect(state.enabled).toBe(false);
+      expect(state.intervalMinutes).toBe(DEFAULT_REMINDER_INTERVAL);
+      expect(logError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          operation: "fetchOrInitData",
+          component: "NotificationsStore",
+        })
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // onWaterDrunk
+  // ---------------------------------------------------------------------------
+  describe("onWaterDrunk", () => {
+    it("should reset notificationsSinceLastDrink counter", async () => {
+      // Put the store in a state with notifications fired
+      useNotificationsStore.setState({
+        notificationsSinceLastDrink: 3,
+        enabled: true,
+        permissionStatus: "granted",
+      });
+
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      expect(useNotificationsStore.getState().notificationsSinceLastDrink).toBe(
+        0
+      );
+    });
+
+    it("should set lastDrinkTimestamp to current time", async () => {
+      const beforeTime = new Date().toISOString();
+
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      const state = useNotificationsStore.getState();
+      expect(state.lastDrinkTimestamp).not.toBeNull();
+      // Timestamp should be at or after the time before the call
+      expect(state.lastDrinkTimestamp! >= beforeTime).toBe(true);
+    });
+
+    it("should persist state after updating timestamp and counter", async () => {
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        NOTIFICATIONS_STORAGE_KEY,
+        expect.any(String)
+      );
+    });
+
+    it("should reschedule notifications when enabled and granted", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        permissionStatus: "granted",
+        intervalMinutes: 60,
+        maxNotifications: 3,
+      });
+
+      (scheduleSmartNotifications as jest.Mock).mockResolvedValue({
+        ids: ["id-1", "id-2"],
+        count: 2,
+      });
+
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      expect(scheduleSmartNotifications).toHaveBeenCalledTimes(1);
+      expect(scheduleSmartNotifications).toHaveBeenCalledWith(
+        expect.objectContaining({
+          intervalMinutes: 60,
+          startHour: "08:00",
+          endHour: "22:00",
+          maxNotifications: 3,
+          notificationsSinceLastDrink: 0,
+          title: "Test",
+          body: "Test body",
+        })
+      );
+
+      expect(useNotificationsStore.getState().scheduledCount).toBe(2);
+    });
+
+    it("should call getNotificationContent statically (not via dynamic import)", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        permissionStatus: "granted",
+      });
+
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      // getNotificationContent is imported at module level and called
+      // synchronously -- not dynamically imported at runtime.
+      expect(getNotificationContent).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not reschedule when not enabled", async () => {
+      useNotificationsStore.setState({
+        enabled: false,
+        permissionStatus: "granted",
+      });
+
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      expect(scheduleSmartNotifications).not.toHaveBeenCalled();
+    });
+
+    it("should not reschedule when permission is not granted", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        permissionStatus: "denied",
+      });
+
+      await useNotificationsStore.getState().onWaterDrunk("08:00", "22:00");
+
+      expect(scheduleSmartNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // onNotificationReceived
+  // ---------------------------------------------------------------------------
+  describe("onNotificationReceived", () => {
+    it("should increment notificationsSinceLastDrink by 1", () => {
+      useNotificationsStore.setState({ notificationsSinceLastDrink: 0 });
+
+      useNotificationsStore.getState().onNotificationReceived();
+
+      expect(useNotificationsStore.getState().notificationsSinceLastDrink).toBe(
+        1
+      );
+    });
+
+    it("should increment from any starting count", () => {
+      useNotificationsStore.setState({ notificationsSinceLastDrink: 5 });
+
+      useNotificationsStore.getState().onNotificationReceived();
+
+      expect(useNotificationsStore.getState().notificationsSinceLastDrink).toBe(
+        6
+      );
+    });
+
+    it("should persist state (fire-and-forget)", () => {
+      useNotificationsStore.setState({ notificationsSinceLastDrink: 0 });
+
+      useNotificationsStore.getState().onNotificationReceived();
+
+      // Fire-and-forget persist -- setItem is called asynchronously
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        NOTIFICATIONS_STORAGE_KEY,
+        expect.any(String)
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // cancelReminders
+  // ---------------------------------------------------------------------------
+  describe("cancelReminders", () => {
+    it("should call cancelAllNotifications", async () => {
+      await useNotificationsStore.getState().cancelReminders();
+
+      expect(cancelAllNotifications).toHaveBeenCalledTimes(1);
+    });
+
+    it("should set lastScheduledTime to null", async () => {
+      useNotificationsStore.setState({
+        lastScheduledTime: "2026-01-28T10:00:00.000Z",
+      });
+
+      await useNotificationsStore.getState().cancelReminders();
+
+      expect(useNotificationsStore.getState().lastScheduledTime).toBeNull();
+    });
+
+    it("should set scheduledCount to 0", async () => {
+      useNotificationsStore.setState({ scheduledCount: 5 });
+
+      await useNotificationsStore.getState().cancelReminders();
+
+      expect(useNotificationsStore.getState().scheduledCount).toBe(0);
+    });
+
+    it("should persist state after cancellation (S6 fix)", async () => {
+      useNotificationsStore.setState({
+        lastScheduledTime: "2026-01-28T10:00:00.000Z",
+        scheduledCount: 5,
+      });
+
+      await useNotificationsStore.getState().cancelReminders();
+
+      // The key fix: cancelReminders must persist state via AsyncStorage.setItem
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        NOTIFICATIONS_STORAGE_KEY,
+        expect.any(String)
+      );
+
+      // Verify persisted data reflects cleared scheduling state
+      const persistedCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+        (call) => call[0] === NOTIFICATIONS_STORAGE_KEY
+      );
+      expect(persistedCall).toBeDefined();
+      const persistedData = JSON.parse(persistedCall![1]);
+      expect(persistedData.lastScheduledTime).toBeNull();
+      expect(persistedData.scheduledCount).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // correctNotificationCount
+  // ---------------------------------------------------------------------------
+  describe("correctNotificationCount", () => {
+    it("should correct counter when notifications have fired", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        scheduledCount: 5,
+        notificationsSinceLastDrink: 1,
+      });
+
+      // 3 remaining means 2 have fired (5 - 3 = 2)
+      (getScheduledNotifications as jest.Mock).mockResolvedValue([
+        { id: "1" },
+        { id: "2" },
+        { id: "3" },
+      ]);
+
+      await useNotificationsStore.getState().correctNotificationCount();
+
+      const state = useNotificationsStore.getState();
+      expect(state.notificationsSinceLastDrink).toBe(3); // 1 + 2 fired
+      expect(state.scheduledCount).toBe(3); // corrected to remaining
+    });
+
+    it("should log warning with drift information when fired > 0", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        scheduledCount: 4,
+        notificationsSinceLastDrink: 0,
+      });
+
+      // 2 remaining means 2 have fired (4 - 2 = 2)
+      (getScheduledNotifications as jest.Mock).mockResolvedValue([
+        { id: "1" },
+        { id: "2" },
+      ]);
+
+      await useNotificationsStore.getState().correctNotificationCount();
+
+      expect(logWarning).toHaveBeenCalledWith(
+        "Notification counter drift corrected",
+        expect.objectContaining({
+          operation: "correctNotificationCount",
+          component: "NotificationsStore",
+          data: expect.objectContaining({
+            fired: 2,
+            previousCount: 0,
+            correctedCount: 2,
+          }),
+        })
+      );
+    });
+
+    it("should persist corrected state", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        scheduledCount: 3,
+        notificationsSinceLastDrink: 0,
+      });
+
+      (getScheduledNotifications as jest.Mock).mockResolvedValue([
+        { id: "1" },
+      ]);
+
+      await useNotificationsStore.getState().correctNotificationCount();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        NOTIFICATIONS_STORAGE_KEY,
+        expect.any(String)
+      );
+    });
+
+    it("should not correct when no notifications have fired", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        scheduledCount: 3,
+        notificationsSinceLastDrink: 0,
+      });
+
+      // All 3 are still scheduled -- 0 fired
+      (getScheduledNotifications as jest.Mock).mockResolvedValue([
+        { id: "1" },
+        { id: "2" },
+        { id: "3" },
+      ]);
+
+      await useNotificationsStore.getState().correctNotificationCount();
+
+      expect(useNotificationsStore.getState().notificationsSinceLastDrink).toBe(
+        0
+      );
+      expect(logWarning).not.toHaveBeenCalled();
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it("should skip correction when not enabled", async () => {
+      useNotificationsStore.setState({
+        enabled: false,
+        scheduledCount: 5,
+      });
+
+      await useNotificationsStore.getState().correctNotificationCount();
+
+      expect(getScheduledNotifications).not.toHaveBeenCalled();
+    });
+
+    it("should skip correction when scheduledCount is 0", async () => {
+      useNotificationsStore.setState({
+        enabled: true,
+        scheduledCount: 0,
+      });
+
+      await useNotificationsStore.getState().correctNotificationCount();
+
+      expect(getScheduledNotifications).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app.json
+++ b/app.json
@@ -55,7 +55,13 @@
         "expo-build-properties"
       ],
       "expo-localization",
-      "expo-web-browser"
+      "expo-web-browser",
+      [
+        "expo-notifications",
+        {
+          "color": "#3b82f6"
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/(tabs)/setup/_layout.tsx
+++ b/app/(tabs)/setup/_layout.tsx
@@ -34,6 +34,13 @@ export default function SetupLayout() {
           headerBackTitle: t("back"),
         }}
       />
+      <Stack.Screen
+        name="reminders"
+        options={{
+          title: t("reminders"),
+          headerBackTitle: t("back"),
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(tabs)/setup/index.tsx
+++ b/app/(tabs)/setup/index.tsx
@@ -16,6 +16,12 @@ export default function SettingsMenu() {
       onPress: () => router.push("/(tabs)/setup/general"),
     },
     {
+      id: "reminders",
+      title: t("reminders"),
+      icon: "bell",
+      onPress: () => router.push("/(tabs)/setup/reminders"),
+    },
+    {
       id: "quick-actions",
       title: t("quickActions"),
       icon: "bolt",

--- a/app/(tabs)/setup/index.tsx
+++ b/app/(tabs)/setup/index.tsx
@@ -44,6 +44,8 @@ export default function SettingsMenu() {
               key={item.id}
               onPress={item.onPress}
               className="bg-gray-50  p-4 rounded-lg flex-row items-center justify-between active:opacity-70"
+              accessibilityRole="button"
+              accessibilityLabel={item.title}
             >
               <View className="flex-row items-center gap-3">
                 <FontAwesome

--- a/app/(tabs)/setup/reminders.tsx
+++ b/app/(tabs)/setup/reminders.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import {
   ScrollView,
   View,
@@ -51,7 +51,7 @@ export default function RemindersSettings() {
   const setupStore = useSetupStore();
 
   const [isInitialized, setIsInitialized] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const isLoading = useRef(false);
 
   useEffect(() => {
     const initialize = async () => {
@@ -63,12 +63,12 @@ export default function RemindersSettings() {
 
   const handleEnableToggle = useCallback(
     async (value: string) => {
-      if (isLoading) return;
+      if (isLoading.current) return;
 
       const shouldEnable = value === "on";
 
       if (shouldEnable) {
-        setIsLoading(true);
+        isLoading.current = true;
         try {
           // Request permissions if not granted
           const status = await requestPermissions();
@@ -102,19 +102,18 @@ export default function RemindersSettings() {
             body,
           );
         } finally {
-          setIsLoading(false);
+          isLoading.current = false;
         }
       } else {
-        setIsLoading(true);
+        isLoading.current = true;
         try {
           await setEnabled(false);
         } finally {
-          setIsLoading(false);
+          isLoading.current = false;
         }
       }
     },
     [
-      isLoading,
       requestPermissions,
       setEnabled,
       scheduleReminders,
@@ -126,7 +125,7 @@ export default function RemindersSettings() {
 
   const handleIntervalChange = useCallback(
     async (value: string) => {
-      if (isLoading) return;
+      if (isLoading.current) return;
 
       const parsedValue = parseInt(value, 10);
 
@@ -135,7 +134,7 @@ export default function RemindersSettings() {
         return;
       }
 
-      setIsLoading(true);
+      isLoading.current = true;
       try {
         await setInterval(parsedValue);
 
@@ -148,11 +147,10 @@ export default function RemindersSettings() {
           body,
         );
       } finally {
-        setIsLoading(false);
+        isLoading.current = false;
       }
     },
     [
-      isLoading,
       setInterval,
       scheduleReminders,
       setupStore.day.startHour,
@@ -162,7 +160,7 @@ export default function RemindersSettings() {
 
   const handleMaxNotificationsChange = useCallback(
     async (value: string) => {
-      if (isLoading) return;
+      if (isLoading.current) return;
 
       const parsedValue = parseInt(value, 10);
 
@@ -170,7 +168,7 @@ export default function RemindersSettings() {
         return;
       }
 
-      setIsLoading(true);
+      isLoading.current = true;
       try {
         await setMaxNotifications(parsedValue);
 
@@ -183,11 +181,10 @@ export default function RemindersSettings() {
           body,
         );
       } finally {
-        setIsLoading(false);
+        isLoading.current = false;
       }
     },
     [
-      isLoading,
       setMaxNotifications,
       scheduleReminders,
       setupStore.day.startHour,
@@ -235,7 +232,7 @@ export default function RemindersSettings() {
           accessibilityRole="button"
           accessibilityLabel={`${t("enableReminders")}: ${enabled ? t("on") : t("off")}`}
           accessibilityHint={t("enableRemindersHint")}
-          accessibilityState={{ disabled: isLoading }}
+          accessibilityState={{ disabled: isLoading.current }}
         >
           <ModalPicker
             label={t("enableReminders")}
@@ -252,7 +249,7 @@ export default function RemindersSettings() {
             accessibilityRole="button"
             accessibilityLabel={`${t("reminderInterval")}: ${intervalOptions.find((opt) => opt.value === String(intervalMinutes))?.label}`}
             accessibilityHint={t("reminderIntervalHint")}
-            accessibilityState={{ disabled: isLoading }}
+            accessibilityState={{ disabled: isLoading.current }}
           >
             <ModalPicker
               label={t("reminderInterval")}
@@ -270,7 +267,7 @@ export default function RemindersSettings() {
             accessibilityRole="button"
             accessibilityLabel={`${t("maxNotifications")}: ${maxNotifications === 0 ? t("unlimited") : maxNotifications}`}
             accessibilityHint={t("maxNotificationsHint")}
-            accessibilityState={{ disabled: isLoading }}
+            accessibilityState={{ disabled: isLoading.current }}
           >
             <ModalPicker
               label={t("maxNotifications")}

--- a/app/(tabs)/setup/reminders.tsx
+++ b/app/(tabs)/setup/reminders.tsx
@@ -16,6 +16,8 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import {
   REMINDER_INTERVALS,
   ReminderInterval,
+  MAX_NOTIFICATION_OPTIONS,
+  MaxNotificationOption,
 } from "@/constants/notifications";
 import { getNotificationContent } from "@/services/notificationService";
 
@@ -26,6 +28,10 @@ function isValidReminderInterval(value: number): value is ReminderInterval {
   return REMINDER_INTERVALS.includes(value as ReminderInterval);
 }
 
+function isValidMaxNotification(value: number): value is MaxNotificationOption {
+  return MAX_NOTIFICATION_OPTIONS.includes(value as MaxNotificationOption);
+}
+
 export default function RemindersSettings() {
   const { t } = useTranslation("setup");
 
@@ -34,11 +40,13 @@ export default function RemindersSettings() {
     enabled,
     intervalMinutes,
     permissionStatus,
+    maxNotifications,
     fetchOrInitData,
     requestPermissions,
     setEnabled,
     setInterval,
     scheduleReminders,
+    setMaxNotifications,
   } = useNotificationsStore();
   const setupStore = useSetupStore();
 
@@ -152,6 +160,41 @@ export default function RemindersSettings() {
     ],
   );
 
+  const handleMaxNotificationsChange = useCallback(
+    async (value: string) => {
+      if (isLoading) return;
+
+      const parsedValue = parseInt(value, 10);
+
+      if (!isValidMaxNotification(parsedValue)) {
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        await setMaxNotifications(parsedValue);
+
+        // Reschedule reminders with new limit
+        const { title, body } = getNotificationContent();
+        await scheduleReminders(
+          setupStore.day.startHour,
+          setupStore.day.endHour,
+          title,
+          body,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      isLoading,
+      setMaxNotifications,
+      scheduleReminders,
+      setupStore.day.startHour,
+      setupStore.day.endHour,
+    ],
+  );
+
   const intervalOptions = REMINDER_INTERVALS.map((interval) => {
     const hours = interval / 60;
     const labelKey = hours === 1 ? "every1Hour" : `every${hours}Hours`;
@@ -160,6 +203,11 @@ export default function RemindersSettings() {
       value: String(interval),
     };
   });
+
+  const maxNotificationOptions = MAX_NOTIFICATION_OPTIONS.map((option) => ({
+    label: option === 0 ? t("unlimited") : String(option),
+    value: String(option),
+  }));
 
   const enableOptions = [
     { label: t("on"), value: "on" },
@@ -211,6 +259,24 @@ export default function RemindersSettings() {
               options={intervalOptions}
               onSelect={handleIntervalChange}
               value={String(intervalMinutes)}
+            />
+          </View>
+        )}
+
+        {/* Max Notifications Selection */}
+        {enabled && (
+          <View
+            accessible={true}
+            accessibilityRole="button"
+            accessibilityLabel={`${t("maxNotifications")}: ${maxNotifications === 0 ? t("unlimited") : maxNotifications}`}
+            accessibilityHint={t("maxNotificationsHint")}
+            accessibilityState={{ disabled: isLoading }}
+          >
+            <ModalPicker
+              label={t("maxNotifications")}
+              options={maxNotificationOptions}
+              onSelect={handleMaxNotificationsChange}
+              value={String(maxNotifications)}
             />
           </View>
         )}

--- a/app/(tabs)/setup/reminders.tsx
+++ b/app/(tabs)/setup/reminders.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import { ScrollView, View, Text, Alert, Linking, Platform } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useNotificationsStore } from "@/stores/notifications";
+import { useSetupStore } from "@/stores/setup";
+import { ModalPicker } from "@/components/ui/ModalPicker";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import {
+  REMINDER_INTERVALS,
+  ReminderInterval,
+} from "@/constants/notifications";
+
+export default function RemindersSettings() {
+  const { t } = useTranslation("setup");
+  const { t: tNotifications } = useTranslation("notifications");
+
+  const notificationsStore = useNotificationsStore();
+  const { fetchOrInitData } = notificationsStore;
+  const setupStore = useSetupStore();
+
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    const initialize = async () => {
+      await fetchOrInitData();
+      setIsInitialized(true);
+    };
+    initialize();
+  }, [fetchOrInitData]);
+
+  const handleEnableToggle = async (value: string) => {
+    const shouldEnable = value === "on";
+
+    if (shouldEnable) {
+      // Request permissions if not granted
+      const status = await notificationsStore.requestPermissions();
+
+      if (status !== "granted") {
+        // Show alert to open settings
+        Alert.alert(t("permissionRequired"), t("permissionDeniedMessage"), [
+          { text: t("cancel"), style: "cancel" },
+          {
+            text: t("openSettings"),
+            onPress: () => {
+              if (Platform.OS === "ios") {
+                Linking.openURL("app-settings:");
+              } else {
+                Linking.openSettings();
+              }
+            },
+          },
+        ]);
+        return;
+      }
+
+      await notificationsStore.setEnabled(true);
+
+      // Schedule notifications
+      await notificationsStore.scheduleReminders(
+        setupStore.day.startHour,
+        setupStore.day.endHour,
+        tNotifications("reminderTitle"),
+        tNotifications("reminderBody"),
+      );
+    } else {
+      await notificationsStore.setEnabled(false);
+    }
+  };
+
+  const handleIntervalChange = async (value: string) => {
+    const interval = parseInt(value, 10) as ReminderInterval;
+    await notificationsStore.setInterval(interval);
+
+    // Reschedule if enabled
+    if (
+      notificationsStore.enabled &&
+      notificationsStore.permissionStatus === "granted"
+    ) {
+      await notificationsStore.scheduleReminders(
+        setupStore.day.startHour,
+        setupStore.day.endHour,
+        tNotifications("reminderTitle"),
+        tNotifications("reminderBody"),
+      );
+    }
+  };
+
+  const intervalOptions = REMINDER_INTERVALS.map((interval) => {
+    const hours = interval / 60;
+    const labelKey = hours === 1 ? "every1Hour" : `every${hours}Hours`;
+    return {
+      label: t(labelKey),
+      value: String(interval),
+    };
+  });
+
+  const enableOptions = [
+    { label: t("on"), value: "on" },
+    { label: t("off"), value: "off" },
+  ];
+
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <ErrorBoundary componentName="Reminders Settings">
+      <ScrollView contentContainerClassName="gap-5 flex-1 p-5">
+        {/* Enable/Disable Reminders */}
+        <View>
+          <ModalPicker
+            label={t("enableReminders")}
+            options={enableOptions}
+            onSelect={handleEnableToggle}
+            value={notificationsStore.enabled ? "on" : "off"}
+          />
+        </View>
+
+        {/* Interval Selection */}
+        {notificationsStore.enabled && (
+          <View>
+            <ModalPicker
+              label={t("reminderInterval")}
+              options={intervalOptions}
+              onSelect={handleIntervalChange}
+              value={String(notificationsStore.intervalMinutes)}
+            />
+          </View>
+        )}
+
+        {/* Activity Hours Info */}
+        <View className="bg-gray-100 rounded-lg p-4 gap-2">
+          <Text className="text-gray-600 font-medium">
+            {t("activityHours")}
+          </Text>
+          <Text className="text-gray-800">
+            {setupStore.day.startHour} - {setupStore.day.endHour}
+          </Text>
+          <Text className="text-gray-500 text-sm">
+            {t("activityHoursDescription")}
+          </Text>
+        </View>
+
+        {/* Permission Status Warning */}
+        {notificationsStore.permissionStatus === "denied" && (
+          <View className="bg-yellow-100 rounded-lg p-4">
+            <Text className="text-yellow-800">{t("permissionDenied")}</Text>
+          </View>
+        )}
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/app/(tabs)/setup/reminders.tsx
+++ b/app/(tabs)/setup/reminders.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { ScrollView, View, Text, Alert, Linking, Platform } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useNotificationsStore } from "@/stores/notifications";
@@ -9,16 +9,24 @@ import {
   REMINDER_INTERVALS,
   ReminderInterval,
 } from "@/constants/notifications";
+import { getNotificationContent } from "@/services/notificationService";
+
+/**
+ * Validates if a number is a valid ReminderInterval
+ */
+function isValidReminderInterval(value: number): value is ReminderInterval {
+  return REMINDER_INTERVALS.includes(value as ReminderInterval);
+}
 
 export default function RemindersSettings() {
   const { t } = useTranslation("setup");
-  const { t: tNotifications } = useTranslation("notifications");
 
   const notificationsStore = useNotificationsStore();
   const { fetchOrInitData } = notificationsStore;
   const setupStore = useSetupStore();
 
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const initialize = async () => {
@@ -28,62 +36,101 @@ export default function RemindersSettings() {
     initialize();
   }, [fetchOrInitData]);
 
-  const handleEnableToggle = async (value: string) => {
-    const shouldEnable = value === "on";
+  const handleEnableToggle = useCallback(
+    async (value: string) => {
+      if (isLoading) return;
 
-    if (shouldEnable) {
-      // Request permissions if not granted
-      const status = await notificationsStore.requestPermissions();
+      const shouldEnable = value === "on";
 
-      if (status !== "granted") {
-        // Show alert to open settings
-        Alert.alert(t("permissionRequired"), t("permissionDeniedMessage"), [
-          { text: t("cancel"), style: "cancel" },
-          {
-            text: t("openSettings"),
-            onPress: () => {
-              if (Platform.OS === "ios") {
-                Linking.openURL("app-settings:");
-              } else {
-                Linking.openSettings();
-              }
-            },
-          },
-        ]);
+      if (shouldEnable) {
+        setIsLoading(true);
+        try {
+          // Request permissions if not granted
+          const status = await notificationsStore.requestPermissions();
+
+          if (status !== "granted") {
+            // Show alert to open settings
+            Alert.alert(t("permissionRequired"), t("permissionDeniedMessage"), [
+              { text: t("cancel"), style: "cancel" },
+              {
+                text: t("openSettings"),
+                onPress: () => {
+                  if (Platform.OS === "ios") {
+                    Linking.openURL("app-settings:");
+                  } else {
+                    Linking.openSettings();
+                  }
+                },
+              },
+            ]);
+            return;
+          }
+
+          await notificationsStore.setEnabled(true);
+
+          // Schedule notifications
+          const { title, body } = getNotificationContent();
+          await notificationsStore.scheduleReminders(
+            setupStore.day.startHour,
+            setupStore.day.endHour,
+            title,
+            body,
+          );
+        } finally {
+          setIsLoading(false);
+        }
+      } else {
+        setIsLoading(true);
+        try {
+          await notificationsStore.setEnabled(false);
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    },
+    [
+      isLoading,
+      notificationsStore,
+      setupStore.day.startHour,
+      setupStore.day.endHour,
+      t,
+    ],
+  );
+
+  const handleIntervalChange = useCallback(
+    async (value: string) => {
+      if (isLoading) return;
+
+      const parsedValue = parseInt(value, 10);
+
+      // Validate that parsed value is a valid ReminderInterval
+      if (!isValidReminderInterval(parsedValue)) {
         return;
       }
 
-      await notificationsStore.setEnabled(true);
+      setIsLoading(true);
+      try {
+        await notificationsStore.setInterval(parsedValue);
 
-      // Schedule notifications
-      await notificationsStore.scheduleReminders(
-        setupStore.day.startHour,
-        setupStore.day.endHour,
-        tNotifications("reminderTitle"),
-        tNotifications("reminderBody"),
-      );
-    } else {
-      await notificationsStore.setEnabled(false);
-    }
-  };
-
-  const handleIntervalChange = async (value: string) => {
-    const interval = parseInt(value, 10) as ReminderInterval;
-    await notificationsStore.setInterval(interval);
-
-    // Reschedule if enabled
-    if (
-      notificationsStore.enabled &&
-      notificationsStore.permissionStatus === "granted"
-    ) {
-      await notificationsStore.scheduleReminders(
-        setupStore.day.startHour,
-        setupStore.day.endHour,
-        tNotifications("reminderTitle"),
-        tNotifications("reminderBody"),
-      );
-    }
-  };
+        // Reschedule reminders - scheduleReminders internally checks if enabled and permissions granted
+        const { title, body } = getNotificationContent();
+        await notificationsStore.scheduleReminders(
+          setupStore.day.startHour,
+          setupStore.day.endHour,
+          title,
+          body,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      isLoading,
+      notificationsStore,
+      setupStore.day.startHour,
+      setupStore.day.endHour,
+    ],
+  );
 
   const intervalOptions = REMINDER_INTERVALS.map((interval) => {
     const hours = interval / 60;
@@ -105,9 +152,19 @@ export default function RemindersSettings() {
 
   return (
     <ErrorBoundary componentName="Reminders Settings">
-      <ScrollView contentContainerClassName="gap-5 flex-1 p-5">
+      <ScrollView
+        contentContainerClassName="gap-5 flex-1 p-5"
+        accessible={true}
+        accessibilityLabel={t("remindersSettingsScreen")}
+      >
         {/* Enable/Disable Reminders */}
-        <View>
+        <View
+          accessible={true}
+          accessibilityRole="button"
+          accessibilityLabel={`${t("enableReminders")}: ${notificationsStore.enabled ? t("on") : t("off")}`}
+          accessibilityHint={t("enableRemindersHint")}
+          accessibilityState={{ disabled: isLoading }}
+        >
           <ModalPicker
             label={t("enableReminders")}
             options={enableOptions}
@@ -118,7 +175,13 @@ export default function RemindersSettings() {
 
         {/* Interval Selection */}
         {notificationsStore.enabled && (
-          <View>
+          <View
+            accessible={true}
+            accessibilityRole="button"
+            accessibilityLabel={`${t("reminderInterval")}: ${intervalOptions.find((opt) => opt.value === String(notificationsStore.intervalMinutes))?.label}`}
+            accessibilityHint={t("reminderIntervalHint")}
+            accessibilityState={{ disabled: isLoading }}
+          >
             <ModalPicker
               label={t("reminderInterval")}
               options={intervalOptions}
@@ -129,7 +192,12 @@ export default function RemindersSettings() {
         )}
 
         {/* Activity Hours Info */}
-        <View className="bg-gray-100 rounded-lg p-4 gap-2">
+        <View
+          className="bg-gray-100 rounded-lg p-4 gap-2"
+          accessible={true}
+          accessibilityRole="text"
+          accessibilityLabel={`${t("activityHours")}: ${setupStore.day.startHour} - ${setupStore.day.endHour}. ${t("activityHoursDescription")}`}
+        >
           <Text className="text-gray-600 font-medium">
             {t("activityHours")}
           </Text>
@@ -143,7 +211,12 @@ export default function RemindersSettings() {
 
         {/* Permission Status Warning */}
         {notificationsStore.permissionStatus === "denied" && (
-          <View className="bg-yellow-100 rounded-lg p-4">
+          <View
+            className="bg-yellow-100 rounded-lg p-4"
+            accessible={true}
+            accessibilityRole="alert"
+            accessibilityLabel={t("permissionDenied")}
+          >
             <Text className="text-yellow-800">{t("permissionDenied")}</Text>
           </View>
         )}

--- a/app/(tabs)/setup/reminders.tsx
+++ b/app/(tabs)/setup/reminders.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState, useCallback } from "react";
-import { ScrollView, View, Text, Alert, Linking, Platform } from "react-native";
+import {
+  ScrollView,
+  View,
+  Text,
+  Alert,
+  Linking,
+  Platform,
+  ActivityIndicator,
+} from "react-native";
 import { useTranslation } from "react-i18next";
 import { useNotificationsStore } from "@/stores/notifications";
 import { useSetupStore } from "@/stores/setup";
@@ -21,8 +29,17 @@ function isValidReminderInterval(value: number): value is ReminderInterval {
 export default function RemindersSettings() {
   const { t } = useTranslation("setup");
 
-  const notificationsStore = useNotificationsStore();
-  const { fetchOrInitData } = notificationsStore;
+  // Destructure specific state and actions to avoid useCallback recreation on every state change
+  const {
+    enabled,
+    intervalMinutes,
+    permissionStatus,
+    fetchOrInitData,
+    requestPermissions,
+    setEnabled,
+    setInterval,
+    scheduleReminders,
+  } = useNotificationsStore();
   const setupStore = useSetupStore();
 
   const [isInitialized, setIsInitialized] = useState(false);
@@ -46,7 +63,7 @@ export default function RemindersSettings() {
         setIsLoading(true);
         try {
           // Request permissions if not granted
-          const status = await notificationsStore.requestPermissions();
+          const status = await requestPermissions();
 
           if (status !== "granted") {
             // Show alert to open settings
@@ -66,11 +83,11 @@ export default function RemindersSettings() {
             return;
           }
 
-          await notificationsStore.setEnabled(true);
+          await setEnabled(true);
 
           // Schedule notifications
           const { title, body } = getNotificationContent();
-          await notificationsStore.scheduleReminders(
+          await scheduleReminders(
             setupStore.day.startHour,
             setupStore.day.endHour,
             title,
@@ -82,7 +99,7 @@ export default function RemindersSettings() {
       } else {
         setIsLoading(true);
         try {
-          await notificationsStore.setEnabled(false);
+          await setEnabled(false);
         } finally {
           setIsLoading(false);
         }
@@ -90,7 +107,9 @@ export default function RemindersSettings() {
     },
     [
       isLoading,
-      notificationsStore,
+      requestPermissions,
+      setEnabled,
+      scheduleReminders,
       setupStore.day.startHour,
       setupStore.day.endHour,
       t,
@@ -110,11 +129,11 @@ export default function RemindersSettings() {
 
       setIsLoading(true);
       try {
-        await notificationsStore.setInterval(parsedValue);
+        await setInterval(parsedValue);
 
         // Reschedule reminders - scheduleReminders internally checks if enabled and permissions granted
         const { title, body } = getNotificationContent();
-        await notificationsStore.scheduleReminders(
+        await scheduleReminders(
           setupStore.day.startHour,
           setupStore.day.endHour,
           title,
@@ -126,7 +145,8 @@ export default function RemindersSettings() {
     },
     [
       isLoading,
-      notificationsStore,
+      setInterval,
+      scheduleReminders,
       setupStore.day.startHour,
       setupStore.day.endHour,
     ],
@@ -147,7 +167,11 @@ export default function RemindersSettings() {
   ];
 
   if (!isInitialized) {
-    return null;
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
   }
 
   return (
@@ -161,7 +185,7 @@ export default function RemindersSettings() {
         <View
           accessible={true}
           accessibilityRole="button"
-          accessibilityLabel={`${t("enableReminders")}: ${notificationsStore.enabled ? t("on") : t("off")}`}
+          accessibilityLabel={`${t("enableReminders")}: ${enabled ? t("on") : t("off")}`}
           accessibilityHint={t("enableRemindersHint")}
           accessibilityState={{ disabled: isLoading }}
         >
@@ -169,16 +193,16 @@ export default function RemindersSettings() {
             label={t("enableReminders")}
             options={enableOptions}
             onSelect={handleEnableToggle}
-            value={notificationsStore.enabled ? "on" : "off"}
+            value={enabled ? "on" : "off"}
           />
         </View>
 
         {/* Interval Selection */}
-        {notificationsStore.enabled && (
+        {enabled && (
           <View
             accessible={true}
             accessibilityRole="button"
-            accessibilityLabel={`${t("reminderInterval")}: ${intervalOptions.find((opt) => opt.value === String(notificationsStore.intervalMinutes))?.label}`}
+            accessibilityLabel={`${t("reminderInterval")}: ${intervalOptions.find((opt) => opt.value === String(intervalMinutes))?.label}`}
             accessibilityHint={t("reminderIntervalHint")}
             accessibilityState={{ disabled: isLoading }}
           >
@@ -186,7 +210,7 @@ export default function RemindersSettings() {
               label={t("reminderInterval")}
               options={intervalOptions}
               onSelect={handleIntervalChange}
-              value={String(notificationsStore.intervalMinutes)}
+              value={String(intervalMinutes)}
             />
           </View>
         )}
@@ -210,7 +234,7 @@ export default function RemindersSettings() {
         </View>
 
         {/* Permission Status Warning */}
-        {notificationsStore.permissionStatus === "denied" && (
+        {permissionStatus === "denied" && (
           <View
             className="bg-yellow-100 rounded-lg p-4"
             accessible={true}

--- a/app/(tabs)/setup/reminders.tsx
+++ b/app/(tabs)/setup/reminders.tsx
@@ -275,6 +275,9 @@ export default function RemindersSettings() {
               onSelect={handleMaxNotificationsChange}
               value={String(maxNotifications)}
             />
+            <Text className="text-gray-500 text-sm mt-1 px-1">
+              {t("maxNotificationsDescription")}
+            </Text>
           </View>
         )}
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ import { useBackupStore } from "@/stores/backup";
 import { useNotificationsStore } from "@/stores/notifications";
 import {
   addNotificationResponseListener,
+  addNotificationReceivedListener,
   getNotificationContent,
 } from "@/services/notificationService";
 import { NOTIFICATION_ACTION_OPEN_HOME } from "@/constants/notifications";
@@ -68,6 +69,18 @@ export default function RootLayout() {
     return () => subscription.remove();
   }, [router]);
 
+  // Track received notifications in foreground to increment counter
+  useEffect(() => {
+    const subscription = addNotificationReceivedListener(() => {
+      const notificationsState = useNotificationsStore.getState();
+      if (notificationsState.enabled) {
+        notificationsState.onNotificationReceived();
+      }
+    });
+
+    return () => subscription.remove();
+  }, []);
+
   // Reschedule notifications when activity hours change (skip initial mount)
   useEffect(() => {
     if (isInitialActivityHoursMount.current) {
@@ -82,36 +95,42 @@ export default function RootLayout() {
   }, [day.startHour, day.endHour, scheduleReminders]);
 
   useEffect(() => {
-    const subscription = AppState.addEventListener("change", (nextAppState) => {
-      if (
-        appState.current.match(/inactive|background/) &&
-        nextAppState === "active"
-      ) {
-        fetchOrInitWaterData();
-        checkAndUnlockAchievements();
+    const subscription = AppState.addEventListener(
+      "change",
+      async (nextAppState) => {
+        if (
+          appState.current.match(/inactive|background/) &&
+          nextAppState === "active"
+        ) {
+          fetchOrInitWaterData();
+          checkAndUnlockAchievements();
 
-        // Reschedule notifications when app becomes active
-        // Use getState() to get fresh values instead of stale closure values
-        // Only reschedule if notifications store has been initialized
-        if (isNotificationsInitialized) {
-          const notificationsState = useNotificationsStore.getState();
-          const setupState = useSetupStore.getState();
-          if (
-            notificationsState.enabled &&
-            notificationsState.permissionStatus === "granted"
-          ) {
-            const { title, body } = getNotificationContent();
-            notificationsState.scheduleReminders(
-              setupState.day.startHour,
-              setupState.day.endHour,
-              title,
-              body,
-            );
+          // Correct notification counter and reschedule when app becomes active
+          // Use getState() to get fresh values instead of stale closure values
+          // Only reschedule if notifications store has been initialized
+          if (isNotificationsInitialized) {
+            const notificationsState = useNotificationsStore.getState();
+            const setupState = useSetupStore.getState();
+            if (
+              notificationsState.enabled &&
+              notificationsState.permissionStatus === "granted"
+            ) {
+              // Correct counter for notifications fired while in background
+              await notificationsState.correctNotificationCount();
+
+              const { title, body } = getNotificationContent();
+              notificationsState.scheduleReminders(
+                setupState.day.startHour,
+                setupState.day.endHour,
+                title,
+                body,
+              );
+            }
           }
         }
-      }
-      appState.current = nextAppState;
-    });
+        appState.current = nextAppState;
+      },
+    );
     fetchOrInitSetup();
     fetchOrInitWaterData();
     fetchOrInitOnboarding();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useFonts } from "expo-font";
 import { Stack, useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import "react-native-reanimated";
 import "../global.css";
 import { useWaterStore } from "@/stores/water";
@@ -30,8 +30,7 @@ export default function RootLayout() {
   const router = useRouter();
   const appState = useRef(AppState.currentState);
   const isInitialActivityHoursMount = useRef(true);
-  const [isNotificationsInitialized, setIsNotificationsInitialized] =
-    useState(false);
+  const isNotificationsInitialized = useRef(false);
   const { fetchOrInitData: fetchOrInitWaterData } = useWaterStore();
   const {
     fetchOrInitData: fetchOrInitSetup,
@@ -108,7 +107,7 @@ export default function RootLayout() {
           // Correct notification counter and reschedule when app becomes active
           // Use getState() to get fresh values instead of stale closure values
           // Only reschedule if notifications store has been initialized
-          if (isNotificationsInitialized) {
+          if (isNotificationsInitialized.current) {
             const notificationsState = useNotificationsStore.getState();
             const setupState = useSetupStore.getState();
             if (
@@ -119,7 +118,7 @@ export default function RootLayout() {
               await notificationsState.correctNotificationCount();
 
               const { title, body } = getNotificationContent();
-              notificationsState.scheduleReminders(
+              await notificationsState.scheduleReminders(
                 setupState.day.startHour,
                 setupState.day.endHour,
                 title,
@@ -136,7 +135,7 @@ export default function RootLayout() {
     fetchOrInitOnboarding();
     fetchOrInitGamification();
     fetchOrInitNotifications().then(() => {
-      setIsNotificationsInitialized(true);
+      isNotificationsInitialized.current = true;
     });
 
     // Create automatic backup on app start (once per day)
@@ -153,7 +152,6 @@ export default function RootLayout() {
     fetchOrInitNotifications,
     checkAndUnlockAchievements,
     createAutomaticBackup,
-    isNotificationsInitialized,
   ]);
 
   useEffect(() => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { useFonts } from "expo-font";
-import { Stack } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect, useRef } from "react";
 import "react-native-reanimated";
@@ -14,21 +14,34 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { useOnboardingStore } from "@/stores/onboarding";
 import { useGamificationStore } from "@/stores/gamification";
 import { useBackupStore } from "@/stores/backup";
+import { useNotificationsStore } from "@/stores/notifications";
+import { addNotificationResponseListener } from "@/services/notificationService";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
+  const router = useRouter();
   const appState = useRef(AppState.currentState);
   const { fetchOrInitData: fetchOrInitWaterData } = useWaterStore();
-  const { fetchOrInitData: fetchOrInitSetup, languageCode } = useSetupStore();
+  const {
+    fetchOrInitData: fetchOrInitSetup,
+    languageCode,
+    day,
+  } = useSetupStore();
   const { fetchOrInitData: fetchOrInitOnboarding } = useOnboardingStore();
   const {
     fetchOrInitData: fetchOrInitGamification,
     checkAndUnlockAchievements,
   } = useGamificationStore();
   const { createAutomaticBackup } = useBackupStore();
+  const {
+    fetchOrInitData: fetchOrInitNotifications,
+    scheduleReminders,
+    enabled: notificationsEnabled,
+    permissionStatus,
+  } = useNotificationsStore();
   const [loaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
@@ -40,6 +53,27 @@ export default function RootLayout() {
     );
   }, [languageCode]);
 
+  // Handle notification tap - deep linking
+  useEffect(() => {
+    const subscription = addNotificationResponseListener((response) => {
+      const data = response.notification.request.content.data;
+      if (data?.action === "open_home") {
+        router.push("/(tabs)/");
+      }
+    });
+
+    return () => subscription.remove();
+  }, [router]);
+
+  // Reschedule notifications when activity hours change
+  useEffect(() => {
+    if (notificationsEnabled && permissionStatus === "granted") {
+      const title = i18n.t("reminderTitle", { ns: "notifications" });
+      const body = i18n.t("reminderBody", { ns: "notifications" });
+      scheduleReminders(day.startHour, day.endHour, title, body);
+    }
+  }, [day.startHour, day.endHour, notificationsEnabled, permissionStatus]);
+
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextAppState) => {
       if (
@@ -48,6 +82,13 @@ export default function RootLayout() {
       ) {
         fetchOrInitWaterData();
         checkAndUnlockAchievements();
+
+        // Reschedule notifications when app becomes active
+        if (notificationsEnabled && permissionStatus === "granted") {
+          const title = i18n.t("reminderTitle", { ns: "notifications" });
+          const body = i18n.t("reminderBody", { ns: "notifications" });
+          scheduleReminders(day.startHour, day.endHour, title, body);
+        }
       }
       appState.current = nextAppState;
     });
@@ -55,6 +96,7 @@ export default function RootLayout() {
     fetchOrInitWaterData();
     fetchOrInitOnboarding();
     fetchOrInitGamification();
+    fetchOrInitNotifications();
 
     // Create automatic backup on app start (once per day)
     createAutomaticBackup();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useFonts } from "expo-font";
 import { Stack, useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import "react-native-reanimated";
 import "../global.css";
 import { useWaterStore } from "@/stores/water";
@@ -28,6 +28,9 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const router = useRouter();
   const appState = useRef(AppState.currentState);
+  const isInitialActivityHoursMount = useRef(true);
+  const [isNotificationsInitialized, setIsNotificationsInitialized] =
+    useState(false);
   const { fetchOrInitData: fetchOrInitWaterData } = useWaterStore();
   const {
     fetchOrInitData: fetchOrInitSetup,
@@ -65,8 +68,12 @@ export default function RootLayout() {
     return () => subscription.remove();
   }, [router]);
 
-  // Reschedule notifications when activity hours change
+  // Reschedule notifications when activity hours change (skip initial mount)
   useEffect(() => {
+    if (isInitialActivityHoursMount.current) {
+      isInitialActivityHoursMount.current = false;
+      return;
+    }
     const { enabled, permissionStatus } = useNotificationsStore.getState();
     if (enabled && permissionStatus === "granted") {
       const { title, body } = getNotificationContent();
@@ -85,19 +92,22 @@ export default function RootLayout() {
 
         // Reschedule notifications when app becomes active
         // Use getState() to get fresh values instead of stale closure values
-        const notificationsState = useNotificationsStore.getState();
-        const setupState = useSetupStore.getState();
-        if (
-          notificationsState.enabled &&
-          notificationsState.permissionStatus === "granted"
-        ) {
-          const { title, body } = getNotificationContent();
-          notificationsState.scheduleReminders(
-            setupState.day.startHour,
-            setupState.day.endHour,
-            title,
-            body,
-          );
+        // Only reschedule if notifications store has been initialized
+        if (isNotificationsInitialized) {
+          const notificationsState = useNotificationsStore.getState();
+          const setupState = useSetupStore.getState();
+          if (
+            notificationsState.enabled &&
+            notificationsState.permissionStatus === "granted"
+          ) {
+            const { title, body } = getNotificationContent();
+            notificationsState.scheduleReminders(
+              setupState.day.startHour,
+              setupState.day.endHour,
+              title,
+              body,
+            );
+          }
         }
       }
       appState.current = nextAppState;
@@ -106,7 +116,9 @@ export default function RootLayout() {
     fetchOrInitWaterData();
     fetchOrInitOnboarding();
     fetchOrInitGamification();
-    fetchOrInitNotifications();
+    fetchOrInitNotifications().then(() => {
+      setIsNotificationsInitialized(true);
+    });
 
     // Create automatic backup on app start (once per day)
     createAutomaticBackup();
@@ -122,6 +134,7 @@ export default function RootLayout() {
     fetchOrInitNotifications,
     checkAndUnlockAchievements,
     createAutomaticBackup,
+    isNotificationsInitialized,
   ]);
 
   useEffect(() => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,7 +15,11 @@ import { useOnboardingStore } from "@/stores/onboarding";
 import { useGamificationStore } from "@/stores/gamification";
 import { useBackupStore } from "@/stores/backup";
 import { useNotificationsStore } from "@/stores/notifications";
-import { addNotificationResponseListener } from "@/services/notificationService";
+import {
+  addNotificationResponseListener,
+  getNotificationContent,
+} from "@/services/notificationService";
+import { NOTIFICATION_ACTION_OPEN_HOME } from "@/constants/notifications";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
@@ -36,12 +40,8 @@ export default function RootLayout() {
     checkAndUnlockAchievements,
   } = useGamificationStore();
   const { createAutomaticBackup } = useBackupStore();
-  const {
-    fetchOrInitData: fetchOrInitNotifications,
-    scheduleReminders,
-    enabled: notificationsEnabled,
-    permissionStatus,
-  } = useNotificationsStore();
+  const { fetchOrInitData: fetchOrInitNotifications, scheduleReminders } =
+    useNotificationsStore();
   const [loaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
@@ -57,7 +57,7 @@ export default function RootLayout() {
   useEffect(() => {
     const subscription = addNotificationResponseListener((response) => {
       const data = response.notification.request.content.data;
-      if (data?.action === "open_home") {
+      if (data?.action === NOTIFICATION_ACTION_OPEN_HOME) {
         router.push("/(tabs)/");
       }
     });
@@ -67,12 +67,12 @@ export default function RootLayout() {
 
   // Reschedule notifications when activity hours change
   useEffect(() => {
-    if (notificationsEnabled && permissionStatus === "granted") {
-      const title = i18n.t("reminderTitle", { ns: "notifications" });
-      const body = i18n.t("reminderBody", { ns: "notifications" });
+    const { enabled, permissionStatus } = useNotificationsStore.getState();
+    if (enabled && permissionStatus === "granted") {
+      const { title, body } = getNotificationContent();
       scheduleReminders(day.startHour, day.endHour, title, body);
     }
-  }, [day.startHour, day.endHour, notificationsEnabled, permissionStatus]);
+  }, [day.startHour, day.endHour, scheduleReminders]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextAppState) => {
@@ -84,10 +84,20 @@ export default function RootLayout() {
         checkAndUnlockAchievements();
 
         // Reschedule notifications when app becomes active
-        if (notificationsEnabled && permissionStatus === "granted") {
-          const title = i18n.t("reminderTitle", { ns: "notifications" });
-          const body = i18n.t("reminderBody", { ns: "notifications" });
-          scheduleReminders(day.startHour, day.endHour, title, body);
+        // Use getState() to get fresh values instead of stale closure values
+        const notificationsState = useNotificationsStore.getState();
+        const setupState = useSetupStore.getState();
+        if (
+          notificationsState.enabled &&
+          notificationsState.permissionStatus === "granted"
+        ) {
+          const { title, body } = getNotificationContent();
+          notificationsState.scheduleReminders(
+            setupState.day.startHour,
+            setupState.day.endHour,
+            title,
+            body,
+          );
         }
       }
       appState.current = nextAppState;
@@ -104,7 +114,15 @@ export default function RootLayout() {
     return () => {
       subscription.remove();
     };
-  }, []);
+  }, [
+    fetchOrInitSetup,
+    fetchOrInitWaterData,
+    fetchOrInitOnboarding,
+    fetchOrInitGamification,
+    fetchOrInitNotifications,
+    checkAndUnlockAchievements,
+    createAutomaticBackup,
+  ]);
 
   useEffect(() => {
     if (loaded) {

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable } from "react-native";
 import { useSetupStore } from "@/stores/setup";
 import { useWaterStore } from "@/stores/water";
 import { useGamificationStore } from "@/stores/gamification";
+import { useNotificationsStore } from "@/stores/notifications";
 import { useTranslation } from "react-i18next";
 import { useHaptics } from "@/hooks/useHaptics";
 import { logError } from "@/utils/errorLogging";
@@ -27,6 +28,19 @@ export default function QuickActions() {
       const newCurrentWater = Number(currentWater) + amount;
       await waterStore.setTodayWater(newCurrentWater.toString());
       gamificationStore.checkAndUnlockAchievements();
+
+      // Reschedule notifications anchored to this drink
+      const notificationsState = useNotificationsStore.getState();
+      if (
+        notificationsState.enabled &&
+        notificationsState.permissionStatus === "granted"
+      ) {
+        const setupState = useSetupStore.getState();
+        await notificationsState.onWaterDrunk(
+          setupState.day.startHour,
+          setupState.day.endHour,
+        );
+      }
     } catch (error) {
       logError(error, {
         operation: "handleQuickAction",

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -2,10 +2,10 @@ import { View, Text, Pressable } from "react-native";
 import { useSetupStore } from "@/stores/setup";
 import { useWaterStore } from "@/stores/water";
 import { useGamificationStore } from "@/stores/gamification";
-import { useNotificationsStore } from "@/stores/notifications";
 import { useTranslation } from "react-i18next";
 import { useHaptics } from "@/hooks/useHaptics";
 import { logError } from "@/utils/errorLogging";
+import { rescheduleNotificationsAfterDrink } from "@/hooks/useWater";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { useMemo } from "react";
 
@@ -30,17 +30,7 @@ export default function QuickActions() {
       gamificationStore.checkAndUnlockAchievements();
 
       // Reschedule notifications anchored to this drink
-      const notificationsState = useNotificationsStore.getState();
-      if (
-        notificationsState.enabled &&
-        notificationsState.permissionStatus === "granted"
-      ) {
-        const setupState = useSetupStore.getState();
-        await notificationsState.onWaterDrunk(
-          setupState.day.startHour,
-          setupState.day.endHour,
-        );
-      }
+      await rescheduleNotificationsAfterDrink();
     } catch (error) {
       logError(error, {
         operation: "handleQuickAction",

--- a/constants/notifications.ts
+++ b/constants/notifications.ts
@@ -17,3 +17,6 @@ export const NOTIFICATIONS_STORAGE_KEY = "notificationsData";
 // Notification channel ID for Android
 export const NOTIFICATION_CHANNEL_ID = "water-reminders";
 export const NOTIFICATION_CHANNEL_NAME = "Water Reminders";
+
+// Deep link action when notification is tapped
+export const NOTIFICATION_ACTION_OPEN_HOME = "open_home";

--- a/constants/notifications.ts
+++ b/constants/notifications.ts
@@ -7,7 +7,7 @@
 export const REMINDER_INTERVALS = [60, 120, 180] as const;
 export type ReminderInterval = (typeof REMINDER_INTERVALS)[number];
 
-// Maximum notification options (0 = unlimited)
+// Maximum notification options — 0 means unlimited and is placed last for UI display order
 export const MAX_NOTIFICATION_OPTIONS = [1, 2, 3, 0] as const;
 export type MaxNotificationOption = (typeof MAX_NOTIFICATION_OPTIONS)[number];
 export const DEFAULT_MAX_NOTIFICATIONS: MaxNotificationOption = 3;
@@ -22,6 +22,9 @@ export const NOTIFICATIONS_STORAGE_KEY = "notificationsData";
 // Notification channel ID for Android
 export const NOTIFICATION_CHANNEL_ID = "water-reminders";
 export const NOTIFICATION_CHANNEL_NAME = "Water Reminders";
+
+// Whether notification sound is enabled
+export const NOTIFICATION_SOUND_ENABLED = true;
 
 // Deep link action when notification is tapped
 export const NOTIFICATION_ACTION_OPEN_HOME = "open_home";

--- a/constants/notifications.ts
+++ b/constants/notifications.ts
@@ -7,6 +7,11 @@
 export const REMINDER_INTERVALS = [60, 120, 180] as const;
 export type ReminderInterval = (typeof REMINDER_INTERVALS)[number];
 
+// Maximum notification options (0 = unlimited)
+export const MAX_NOTIFICATION_OPTIONS = [1, 2, 3, 0] as const;
+export type MaxNotificationOption = (typeof MAX_NOTIFICATION_OPTIONS)[number];
+export const DEFAULT_MAX_NOTIFICATIONS: MaxNotificationOption = 3;
+
 // Default values
 export const DEFAULT_REMINDER_INTERVAL: ReminderInterval = 120;
 export const DEFAULT_REMINDERS_ENABLED = false;

--- a/constants/notifications.ts
+++ b/constants/notifications.ts
@@ -1,0 +1,19 @@
+/**
+ * Notification-related constants for Water Tracker Hydration app.
+ * Centralizes configuration for push notification reminders.
+ */
+
+// Available reminder intervals in minutes
+export const REMINDER_INTERVALS = [60, 120, 180] as const;
+export type ReminderInterval = (typeof REMINDER_INTERVALS)[number];
+
+// Default values
+export const DEFAULT_REMINDER_INTERVAL: ReminderInterval = 120;
+export const DEFAULT_REMINDERS_ENABLED = false;
+
+// Storage key for notifications store
+export const NOTIFICATIONS_STORAGE_KEY = "notificationsData";
+
+// Notification channel ID for Android
+export const NOTIFICATION_CHANNEL_ID = "water-reminders";
+export const NOTIFICATION_CHANNEL_NAME = "Water Reminders";

--- a/hooks/useWater.ts
+++ b/hooks/useWater.ts
@@ -6,6 +6,24 @@ import { useNotificationsStore } from "@/stores/notifications";
 import { roundBy } from "@/utils/numbers";
 import { logError } from "@/utils/errorLogging";
 
+/**
+ * Reschedules notifications anchored to the current drink event.
+ * Shared by addWater (useWater hook) and QuickActions component.
+ */
+export async function rescheduleNotificationsAfterDrink(): Promise<void> {
+  const notificationsState = useNotificationsStore.getState();
+  if (
+    notificationsState.enabled &&
+    notificationsState.permissionStatus === "granted"
+  ) {
+    const setupState = useSetupStore.getState();
+    await notificationsState.onWaterDrunk(
+      setupState.day.startHour,
+      setupState.day.endHour,
+    );
+  }
+}
+
 export function useWater() {
   const waterStore = useWaterStore();
   const setupStore = useSetupStore();
@@ -38,16 +56,7 @@ export function useWater() {
       gamificationStore.checkAndUnlockAchievements();
 
       // Reschedule notifications anchored to this drink
-      const notificationsState = useNotificationsStore.getState();
-      if (
-        notificationsState.enabled &&
-        notificationsState.permissionStatus === "granted"
-      ) {
-        await notificationsState.onWaterDrunk(
-          setupStore.day.startHour,
-          setupStore.day.endHour,
-        );
-      }
+      await rescheduleNotificationsAfterDrink();
     } catch (error) {
       logError(error, {
         operation: "addWater",

--- a/hooks/useWater.ts
+++ b/hooks/useWater.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useWaterStore } from "@/stores/water";
 import { useSetupStore } from "@/stores/setup";
 import { useGamificationStore } from "@/stores/gamification";
+import { useNotificationsStore } from "@/stores/notifications";
 import { roundBy } from "@/utils/numbers";
 import { logError } from "@/utils/errorLogging";
 
@@ -35,6 +36,18 @@ export function useWater() {
         Number(currentWater) + Number(setupStore.glassCapacity);
       await waterStore.setTodayWater(newCurrentWater.toString());
       gamificationStore.checkAndUnlockAchievements();
+
+      // Reschedule notifications anchored to this drink
+      const notificationsState = useNotificationsStore.getState();
+      if (
+        notificationsState.enabled &&
+        notificationsState.permissionStatus === "granted"
+      ) {
+        await notificationsState.onWaterDrunk(
+          setupStore.day.startHour,
+          setupStore.day.endHour,
+        );
+      }
     } catch (error) {
       logError(error, {
         operation: "addWater",

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -5,6 +5,7 @@ import languages from "@/i18n/en/languages.json";
 import onboarding from "@/i18n/en/onboarding.json";
 import gamification from "@/i18n/en/gamification.json";
 import errors from "@/i18n/en/errors.json";
+import notifications from "@/i18n/en/notifications.json";
 
 export default {
   translation,
@@ -14,4 +15,5 @@ export default {
   onboarding,
   gamification,
   errors,
+  notifications,
 };

--- a/i18n/en/notifications.json
+++ b/i18n/en/notifications.json
@@ -1,0 +1,4 @@
+{
+  "reminderTitle": "Time to drink water!",
+  "reminderBody": "Stay hydrated! Take a moment to drink some water."
+}

--- a/i18n/en/notifications.json
+++ b/i18n/en/notifications.json
@@ -1,4 +1,6 @@
 {
   "reminderTitle": "Time to drink water!",
-  "reminderBody": "Stay hydrated! Take a moment to drink some water."
+  "reminderBody": "Stay hydrated! Take a moment to drink some water.",
+  "channelName": "Water Reminders",
+  "channelDescription": "Reminders to stay hydrated throughout the day"
 }

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -26,5 +26,17 @@
   "confirmDelete": "Confirm Delete",
   "confirmDeleteQuickAction": "Are you sure you want to delete this quick action?",
   "cancel": "Cancel",
-  "delete": "Delete"
+  "delete": "Delete",
+  "reminders": "Reminders",
+  "enableReminders": "Enable reminders",
+  "reminderInterval": "Reminder interval",
+  "every1Hour": "Every 1 hour",
+  "every2Hours": "Every 2 hours",
+  "every3Hours": "Every 3 hours",
+  "activityHours": "Activity hours",
+  "activityHoursDescription": "Reminders will only be sent during your activity hours. You can change these in General settings.",
+  "permissionRequired": "Permission Required",
+  "permissionDeniedMessage": "Notifications are disabled. Please enable them in your device settings to receive water reminders.",
+  "permissionDenied": "Notification permissions are denied. Please enable them in your device settings.",
+  "openSettings": "Open Settings"
 }

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -41,5 +41,8 @@
   "openSettings": "Open Settings",
   "remindersSettingsScreen": "Reminders settings",
   "enableRemindersHint": "Double tap to toggle water reminders on or off",
-  "reminderIntervalHint": "Double tap to change how often you receive reminders"
+  "reminderIntervalHint": "Double tap to change how often you receive reminders",
+  "maxNotifications": "Max reminders before next drink",
+  "maxNotificationsHint": "Double tap to change the maximum number of reminders before your next drink",
+  "unlimited": "Unlimited"
 }

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -38,5 +38,8 @@
   "permissionRequired": "Permission Required",
   "permissionDeniedMessage": "Notifications are disabled. Please enable them in your device settings to receive water reminders.",
   "permissionDenied": "Notification permissions are denied. Please enable them in your device settings.",
-  "openSettings": "Open Settings"
+  "openSettings": "Open Settings",
+  "remindersSettingsScreen": "Reminders settings",
+  "enableRemindersHint": "Double tap to toggle water reminders on or off",
+  "reminderIntervalHint": "Double tap to change how often you receive reminders"
 }

--- a/i18n/en/setup.json
+++ b/i18n/en/setup.json
@@ -44,5 +44,6 @@
   "reminderIntervalHint": "Double tap to change how often you receive reminders",
   "maxNotifications": "Max reminders before next drink",
   "maxNotificationsHint": "Double tap to change the maximum number of reminders before your next drink",
+  "maxNotificationsDescription": "Limits how many reminder notifications you receive before logging a drink. Set to 'Unlimited' to keep receiving reminders until you drink.",
   "unlimited": "Unlimited"
 }

--- a/i18n/pl.ts
+++ b/i18n/pl.ts
@@ -5,6 +5,7 @@ import languages from "@/i18n/pl/languages.json";
 import onboarding from "@/i18n/pl/onboarding.json";
 import gamification from "@/i18n/pl/gamification.json";
 import errors from "@/i18n/pl/errors.json";
+import notifications from "@/i18n/pl/notifications.json";
 
 export default {
   translation,
@@ -14,4 +15,5 @@ export default {
   onboarding,
   gamification,
   errors,
+  notifications,
 };

--- a/i18n/pl/notifications.json
+++ b/i18n/pl/notifications.json
@@ -1,0 +1,4 @@
+{
+  "reminderTitle": "Czas na wodę!",
+  "reminderBody": "Pamiętaj o nawodnieniu! Napij się wody."
+}

--- a/i18n/pl/notifications.json
+++ b/i18n/pl/notifications.json
@@ -1,4 +1,6 @@
 {
   "reminderTitle": "Czas na wodę!",
-  "reminderBody": "Pamiętaj o nawodnieniu! Napij się wody."
+  "reminderBody": "Pamiętaj o nawodnieniu! Napij się wody.",
+  "channelName": "Przypomnienia o wodzie",
+  "channelDescription": "Przypomnienia o nawadnianiu się w ciągu dnia"
 }

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -38,5 +38,8 @@
   "permissionRequired": "Wymagane uprawnienia",
   "permissionDeniedMessage": "Powiadomienia są wyłączone. Włącz je w ustawieniach urządzenia, aby otrzymywać przypomnienia o piciu wody.",
   "permissionDenied": "Uprawnienia do powiadomień zostały odrzucone. Włącz je w ustawieniach urządzenia.",
-  "openSettings": "Otwórz ustawienia"
+  "openSettings": "Otwórz ustawienia",
+  "remindersSettingsScreen": "Ustawienia przypomnień",
+  "enableRemindersHint": "Dotknij dwukrotnie, aby włączyć lub wyłączyć przypomnienia o piciu wody",
+  "reminderIntervalHint": "Dotknij dwukrotnie, aby zmienić częstotliwość przypomnień"
 }

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -44,5 +44,6 @@
   "reminderIntervalHint": "Dotknij dwukrotnie, aby zmienić częstotliwość przypomnień",
   "maxNotifications": "Maks. przypomnienia przed kolejnym piciem",
   "maxNotificationsHint": "Dotknij dwukrotnie, aby zmienić maksymalną liczbę przypomnień przed kolejnym piciem",
+  "maxNotificationsDescription": "Ogranicza liczbę przypomnień, które otrzymasz przed zalogowaniem napoju. Ustaw na 'Bez limitu', aby otrzymywać przypomnienia do momentu wypicia.",
   "unlimited": "Bez limitu"
 }

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -26,5 +26,17 @@
   "confirmDelete": "Potwierdź usunięcie",
   "confirmDeleteQuickAction": "Czy na pewno chcesz usunąć tę szybką akcję?",
   "cancel": "Anuluj",
-  "delete": "Usuń"
+  "delete": "Usuń",
+  "reminders": "Przypomnienia",
+  "enableReminders": "Włącz przypomnienia",
+  "reminderInterval": "Częstotliwość przypomnień",
+  "every1Hour": "Co 1 godzinę",
+  "every2Hours": "Co 2 godziny",
+  "every3Hours": "Co 3 godziny",
+  "activityHours": "Godziny aktywności",
+  "activityHoursDescription": "Przypomnienia będą wysyłane tylko w godzinach Twojej aktywności. Możesz je zmienić w ustawieniach ogólnych.",
+  "permissionRequired": "Wymagane uprawnienia",
+  "permissionDeniedMessage": "Powiadomienia są wyłączone. Włącz je w ustawieniach urządzenia, aby otrzymywać przypomnienia o piciu wody.",
+  "permissionDenied": "Uprawnienia do powiadomień zostały odrzucone. Włącz je w ustawieniach urządzenia.",
+  "openSettings": "Otwórz ustawienia"
 }

--- a/i18n/pl/setup.json
+++ b/i18n/pl/setup.json
@@ -41,5 +41,8 @@
   "openSettings": "Otwórz ustawienia",
   "remindersSettingsScreen": "Ustawienia przypomnień",
   "enableRemindersHint": "Dotknij dwukrotnie, aby włączyć lub wyłączyć przypomnienia o piciu wody",
-  "reminderIntervalHint": "Dotknij dwukrotnie, aby zmienić częstotliwość przypomnień"
+  "reminderIntervalHint": "Dotknij dwukrotnie, aby zmienić częstotliwość przypomnień",
+  "maxNotifications": "Maks. przypomnienia przed kolejnym piciem",
+  "maxNotificationsHint": "Dotknij dwukrotnie, aby zmienić maksymalną liczbę przypomnień przed kolejnym piciem",
+  "unlimited": "Bez limitu"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydration-project",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydration-project",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",
         "@gorhom/bottom-sheet": "^5.1.4",
@@ -26,6 +26,7 @@
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
         "expo-localization": "~16.1.6",
+        "expo-notifications": "^0.32.16",
         "expo-print": "^15.0.7",
         "expo-router": "~5.1.7",
         "expo-sharing": "~13.1.5",
@@ -2434,6 +2435,33 @@
       "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.5.6.tgz",
       "integrity": "sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w=="
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4537,6 +4565,19 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4561,7 +4602,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -4774,6 +4814,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5015,7 +5061,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -5033,7 +5078,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -5046,7 +5090,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -5937,7 +5980,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -5963,7 +6005,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -6170,7 +6211,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -6327,7 +6367,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6336,7 +6375,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6372,7 +6410,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -7313,6 +7350,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "11.1.7",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.7.tgz",
@@ -7489,6 +7535,250 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.16",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.16.tgz",
+      "integrity": "sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config": {
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
+      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "^10.0.8",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "~3.35.1"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-plugins": {
+      "version": "54.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
+      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "~10.0.8",
+        "@expo/plist": "^0.4.8",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-types": {
+      "version": "54.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
+      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-notifications/node_modules/@expo/env": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.8.tgz",
+      "integrity": "sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^2.0.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/image-utils": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.8.tgz",
+      "integrity": "sha512-HHHaG4J4nKjTtVa1GG9PCh763xlETScfEyNxxOvfTRr8IKPJckjTyqSLEtdJoFNJ1vqiABEjW7tqGhqGibZLeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.0.0",
+        "getenv": "^2.0.0",
+        "jimp-compact": "0.16.1",
+        "parse-png": "^2.1.0",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0",
+        "semver": "^7.6.0",
+        "temp-dir": "~2.0.0",
+        "unique-string": "~2.0.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/json-file": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
+      "integrity": "sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/plist": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
+      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/expo-constants": {
+      "version": "18.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
+      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/env": "~2.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/glob": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/expo-print": {
@@ -7923,7 +8213,6 @@
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
-      "dev": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -8044,7 +8333,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -8186,7 +8474,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -8218,7 +8505,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -8340,6 +8626,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -8368,7 +8666,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8419,7 +8716,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -8446,7 +8742,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8458,7 +8753,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -8812,6 +9106,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8920,7 +9230,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9042,7 +9351,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "get-proto": "^1.0.0",
@@ -9072,6 +9380,22 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -9136,7 +9460,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -9226,7 +9549,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -10853,7 +11175,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -11666,11 +11987,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -11679,7 +12015,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -12252,7 +12587,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -13435,6 +13769,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -13643,7 +13989,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -13864,7 +14209,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -14740,7 +15084,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
       "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
-      "dev": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -14756,7 +15099,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -15248,6 +15590,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15509,7 +15864,6 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
         "expo-localization": "~16.1.6",
-        "expo-notifications": "^0.32.16",
+        "expo-notifications": "^0.31.4",
         "expo-print": "^15.0.7",
         "expo-router": "~5.1.7",
         "expo-sharing": "~13.1.5",
@@ -2440,27 +2440,6 @@
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
       "license": "MIT"
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -7351,9 +7330,9 @@
       }
     },
     "node_modules/expo-application": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
-      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.1.5.tgz",
+      "integrity": "sha512-ToImFmzw8luY043pWFJhh2ZMm4IwxXoHXxNoGdlhD4Ym6+CCmkAvCglg0FK8dMLzAb+/XabmOE7Rbm8KZb6NZg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -7538,247 +7517,23 @@
       }
     },
     "node_modules/expo-notifications": {
-      "version": "0.32.16",
-      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.16.tgz",
-      "integrity": "sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.31.4.tgz",
+      "integrity": "sha512-NnGKIFGpgZU66qfiFUyjEBYsS77VahURpSSeWEOLt+P1zOaUFlgx2XqS+dxH3/Bn1Vm7TMj04qKsK5KvzR/8Lw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.8.8",
+        "@expo/image-utils": "^0.7.6",
         "@ide/backoff": "^1.0.0",
         "abort-controller": "^3.0.0",
         "assert": "^2.0.0",
         "badgin": "^1.1.5",
-        "expo-application": "~7.0.8",
-        "expo-constants": "~18.0.13"
+        "expo-application": "~6.1.5",
+        "expo-constants": "~17.1.7"
       },
       "peerDependencies": {
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "~3.35.1"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/config-plugins": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
-      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "~10.0.8",
-        "@expo/plist": "^0.4.8",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slash": "^3.0.0",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/config-types": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
-      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
-      "license": "MIT"
-    },
-    "node_modules/expo-notifications/node_modules/@expo/env": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.8.tgz",
-      "integrity": "sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "debug": "^4.3.4",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^2.0.0"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/image-utils": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.8.tgz",
-      "integrity": "sha512-HHHaG4J4nKjTtVa1GG9PCh763xlETScfEyNxxOvfTRr8IKPJckjTyqSLEtdJoFNJ1vqiABEjW7tqGhqGibZLeA==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/spawn-async": "^1.7.2",
-        "chalk": "^4.0.0",
-        "getenv": "^2.0.0",
-        "jimp-compact": "0.16.1",
-        "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0",
-        "semver": "^7.6.0",
-        "temp-dir": "~2.0.0",
-        "unique-string": "~2.0.0"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/json-file": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
-      "integrity": "sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/sucrase": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "tinyglobby": "^0.2.11",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/expo-print": {
@@ -8213,6 +7968,7 @@
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -8624,18 +8380,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/globals": {
@@ -13769,18 +13513,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -15084,6 +14816,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
       "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "dev": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -15099,6 +14832,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
     "expo-localization": "~16.1.6",
+    "expo-notifications": "^0.32.16",
     "expo-print": "^15.0.7",
     "expo-router": "~5.1.7",
     "expo-sharing": "~13.1.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
     "expo-localization": "~16.1.6",
-    "expo-notifications": "^0.32.16",
+    "expo-notifications": "^0.31.4",
     "expo-print": "^15.0.7",
     "expo-router": "~5.1.7",
     "expo-sharing": "~13.1.5",

--- a/services/__tests__/notificationService.test.ts
+++ b/services/__tests__/notificationService.test.ts
@@ -1,0 +1,639 @@
+import {
+  initializeNotificationHandler,
+  getNotificationContent,
+  calculateNotificationTimes,
+  calculateSmartNotificationTimes,
+  SmartScheduleParams,
+} from "../notificationService";
+
+// Mock expo-notifications
+jest.mock("expo-notifications", () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelAllScheduledNotificationsAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(),
+  addNotificationReceivedListener: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
+  AndroidImportance: { HIGH: 4 },
+  SchedulableTriggerInputTypes: { DATE: "date" },
+}));
+
+// Mock react-native Platform
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+// Mock error logging
+jest.mock("@/utils/errorLogging", () => ({
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+  logWarning: jest.fn(),
+}));
+
+// Mock i18n
+jest.mock("@/plugins/i18n", () => ({
+  __esModule: true,
+  default: {
+    t: jest.fn((key: string) => {
+      const translations: Record<string, string> = {
+        reminderTitle: "Time to drink water!",
+        reminderBody: "Stay hydrated throughout the day.",
+        channelName: "Water Reminders",
+        channelDescription: "Reminders to drink water",
+      };
+      return translations[key] ?? key;
+    }),
+  },
+}));
+
+// Mock notification constants
+jest.mock("@/constants/notifications", () => ({
+  NOTIFICATION_CHANNEL_ID: "water-reminders",
+  NOTIFICATION_ACTION_OPEN_HOME: "open_home",
+  NOTIFICATION_SOUND_ENABLED: true,
+}));
+
+import * as Notifications from "expo-notifications";
+import { logWarning } from "@/utils/errorLogging";
+
+describe("NotificationService", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Set system time to 2024-06-15 10:00:00 (Saturday)
+    jest.setSystemTime(new Date("2024-06-15T10:00:00"));
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // initializeNotificationHandler
+  // ---------------------------------------------------------------------------
+  describe("initializeNotificationHandler", () => {
+    it("should call Notifications.setNotificationHandler with correct config", () => {
+      initializeNotificationHandler();
+
+      expect(Notifications.setNotificationHandler).toHaveBeenCalledTimes(1);
+      expect(Notifications.setNotificationHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          handleNotification: expect.any(Function),
+        })
+      );
+    });
+
+    it("should configure handler to show alert, play sound, and not set badge", async () => {
+      initializeNotificationHandler();
+
+      const handlerArg = (
+        Notifications.setNotificationHandler as jest.Mock
+      ).mock.calls[0][0];
+
+      const result = await handlerArg.handleNotification();
+
+      expect(result).toEqual({
+        shouldShowAlert: true,
+        shouldPlaySound: true,
+        shouldSetBadge: false,
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getNotificationContent
+  // ---------------------------------------------------------------------------
+  describe("getNotificationContent", () => {
+    it("should return localized title and body", () => {
+      const content = getNotificationContent();
+
+      expect(content).toEqual({
+        title: "Time to drink water!",
+        body: "Stay hydrated throughout the day.",
+      });
+    });
+
+    it("should call i18n.t with correct namespace", () => {
+      const i18n = require("@/plugins/i18n").default;
+
+      getNotificationContent();
+
+      expect(i18n.t).toHaveBeenCalledWith("reminderTitle", {
+        ns: "notifications",
+      });
+      expect(i18n.t).toHaveBeenCalledWith("reminderBody", {
+        ns: "notifications",
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // calculateNotificationTimes
+  // ---------------------------------------------------------------------------
+  describe("calculateNotificationTimes", () => {
+    it("should return empty array for invalid startHour format", () => {
+      const result = calculateNotificationTimes(60, "invalid", "18:00");
+
+      expect(result).toEqual([]);
+      expect(logWarning).toHaveBeenCalledWith(
+        "Invalid time format for notification scheduling",
+        expect.objectContaining({
+          operation: "calculateNotificationTimes",
+          component: "NotificationService",
+        })
+      );
+    });
+
+    it("should return empty array for invalid endHour format", () => {
+      const result = calculateNotificationTimes(60, "08:00", "25:00");
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for overnight schedule (endHour <= startHour)", () => {
+      const result = calculateNotificationTimes(60, "22:00", "06:00");
+
+      expect(result).toEqual([]);
+      expect(logWarning).toHaveBeenCalledWith(
+        expect.stringContaining("Overnight schedule detected"),
+        expect.objectContaining({
+          operation: "calculateNotificationTimes",
+          component: "NotificationService",
+        })
+      );
+    });
+
+    it("should return empty array when endHour equals startHour", () => {
+      const result = calculateNotificationTimes(60, "10:00", "10:00");
+
+      expect(result).toEqual([]);
+    });
+
+    it("should generate correct number of future times within activity hours", () => {
+      // System time: 2024-06-15T10:00:00
+      // Activity: 08:00-18:00, interval: 60 min
+      // Today: next interval after 10:00 is 10:00 (ceil of (120-0)/60 = 2 intervals since 08:00)
+      //   -> 10:00 is at the boundary, the first future time is 11:00, 12:00, ..., 17:00 (7 times for today after 10:00)
+      // Actually let's trace the algorithm:
+      //   nowMinutes = 600, startMinutes = 480
+      //   intervalsSinceStart = ceil((600 - 480) / 60) = ceil(2) = 2
+      //   currentMinutes = 480 + 2*60 = 600 (10:00)
+      //   10:00 on today is NOT > new Date() (it's equal), so skipped
+      //   then 11:00, 12:00, ..., 17:00 -> 7 times for today
+      // Tomorrow: 08:00, 09:00, ..., 17:00 -> 10 times for tomorrow
+      // Total: 17 times
+      const result = calculateNotificationTimes(60, "08:00", "18:00");
+
+      expect(result.length).toBe(17);
+
+      // Verify all times are in the future
+      const now = new Date("2024-06-15T10:00:00");
+      result.forEach((time) => {
+        expect(time.getTime()).toBeGreaterThan(now.getTime());
+      });
+    });
+
+    it("should start from next interval after current time for today", () => {
+      // System time: 10:00, start: 08:00, interval: 120 min
+      // intervalsSinceStart = ceil((600 - 480) / 120) = ceil(1) = 1
+      // currentMinutes = 480 + 1*120 = 600 (10:00) - equal to now, skipped
+      // next: 12:00, 14:00, 16:00 -> 3 times for today
+      const result = calculateNotificationTimes(120, "08:00", "18:00");
+
+      const todayTimes = result.filter(
+        (t) => t.getDate() === 15 && t.getMonth() === 5
+      );
+      expect(todayTimes.length).toBe(3);
+      expect(todayTimes[0].getHours()).toBe(12);
+      expect(todayTimes[1].getHours()).toBe(14);
+      expect(todayTimes[2].getHours()).toBe(16);
+    });
+
+    it("should include tomorrow times starting from startHour", () => {
+      const result = calculateNotificationTimes(120, "08:00", "18:00");
+
+      const tomorrowTimes = result.filter(
+        (t) => t.getDate() === 16 && t.getMonth() === 5
+      );
+      expect(tomorrowTimes.length).toBe(5); // 08:00, 10:00, 12:00, 14:00, 16:00
+      expect(tomorrowTimes[0].getHours()).toBe(8);
+      expect(tomorrowTimes[0].getMinutes()).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // calculateSmartNotificationTimes
+  // ---------------------------------------------------------------------------
+  describe("calculateSmartNotificationTimes", () => {
+    const defaultParams: SmartScheduleParams = {
+      intervalMinutes: 60,
+      startHour: "08:00",
+      endHour: "18:00",
+      lastDrinkTimestamp: null,
+      maxNotifications: 0, // unlimited
+      notificationsSinceLastDrink: 0,
+    };
+
+    // --- Validation tests ---
+
+    it("should return empty array for invalid startHour format", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        startHour: "abc",
+      });
+
+      expect(result).toEqual([]);
+      expect(logWarning).toHaveBeenCalledWith(
+        "Invalid time format for smart notification scheduling",
+        expect.objectContaining({
+          operation: "calculateSmartNotificationTimes",
+          component: "NotificationService",
+        })
+      );
+    });
+
+    it("should return empty array for invalid endHour format", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        endHour: "25:00",
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for overnight schedule (endHour <= startHour)", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        startHour: "22:00",
+        endHour: "06:00",
+      });
+
+      expect(result).toEqual([]);
+      expect(logWarning).toHaveBeenCalledWith(
+        "Overnight schedule not supported for smart notifications",
+        expect.objectContaining({
+          operation: "calculateSmartNotificationTimes",
+          component: "NotificationService",
+        })
+      );
+    });
+
+    it("should return empty array when endHour equals startHour", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        startHour: "12:00",
+        endHour: "12:00",
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    // --- Remaining notifications tests ---
+
+    it("should return empty array when remaining notifications <= 0", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 3,
+        notificationsSinceLastDrink: 3,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when notificationsSinceLastDrink exceeds maxNotifications", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 2,
+        notificationsSinceLastDrink: 5,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should respect max notification limit", () => {
+      // maxNotifications=2, notificationsSinceLastDrink=0 -> remaining=2
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 2,
+        notificationsSinceLastDrink: 0,
+      });
+
+      expect(result.length).toBeLessThanOrEqual(2);
+      expect(result.length).toBe(2);
+    });
+
+    it("should respect remaining count (maxNotifications - notificationsSinceLastDrink)", () => {
+      // maxNotifications=3, notificationsSinceLastDrink=1 -> remaining=2
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 3,
+        notificationsSinceLastDrink: 1,
+      });
+
+      expect(result.length).toBeLessThanOrEqual(2);
+    });
+
+    // --- Anchor determination tests ---
+
+    it("should use lastDrinkTimestamp as anchor when it is from today", () => {
+      // System time: 2024-06-15T10:00:00
+      // Last drink at 09:30 today, interval 60 min
+      // Anchor: 09:30 -> first candidate at 10:30, then 11:30, etc.
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        lastDrinkTimestamp: "2024-06-15T09:30:00",
+        intervalMinutes: 60,
+      });
+
+      // First notification should be anchored from 09:30 + 60 = 10:30
+      expect(result.length).toBeGreaterThan(0);
+      const firstTime = result[0];
+      expect(firstTime.getHours()).toBe(10);
+      expect(firstTime.getMinutes()).toBe(30);
+    });
+
+    it("should use now as anchor when lastDrinkTimestamp is from yesterday", () => {
+      // System time: 2024-06-15T10:00:00
+      // Last drink yesterday at 15:00
+      // Anchor: now (10:00) -> first candidate at 11:00, then 12:00, etc.
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        lastDrinkTimestamp: "2024-06-14T15:00:00",
+        intervalMinutes: 60,
+      });
+
+      expect(result.length).toBeGreaterThan(0);
+      const firstTime = result[0];
+      expect(firstTime.getHours()).toBe(11);
+      expect(firstTime.getMinutes()).toBe(0);
+    });
+
+    it("should use now as anchor when lastDrinkTimestamp is null", () => {
+      // System time: 2024-06-15T10:00:00
+      // No last drink -> anchor is now (10:00)
+      // first candidate at 11:00
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        lastDrinkTimestamp: null,
+        intervalMinutes: 60,
+      });
+
+      expect(result.length).toBeGreaterThan(0);
+      const firstTime = result[0];
+      expect(firstTime.getHours()).toBe(11);
+      expect(firstTime.getMinutes()).toBe(0);
+    });
+
+    it("should use now as anchor when lastDrinkTimestamp is invalid", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        lastDrinkTimestamp: "not-a-date",
+        intervalMinutes: 60,
+      });
+
+      // Should still generate times using now as anchor
+      expect(result.length).toBeGreaterThan(0);
+      const firstTime = result[0];
+      expect(firstTime.getHours()).toBe(11);
+      expect(firstTime.getMinutes()).toBe(0);
+    });
+
+    // --- Activity hours filtering tests ---
+
+    it("should exclude times before activity start hour", () => {
+      // System time: 10:00, last drink at 06:00 today
+      // Anchor: 06:00, interval: 60
+      // Candidates: 07:00, 08:00, 09:00, 10:00, 11:00...
+      // Activity hours: 08:00-18:00
+      // 07:00 is before startHour -> excluded
+      // 08:00, 09:00, 10:00 are in the past or equal to now -> excluded
+      // First valid: 11:00
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        lastDrinkTimestamp: "2024-06-15T06:00:00",
+        intervalMinutes: 60,
+        startHour: "08:00",
+        endHour: "18:00",
+      });
+
+      result.forEach((time) => {
+        if (time.getDate() === 15) {
+          const minutes = time.getHours() * 60 + time.getMinutes();
+          expect(minutes).toBeGreaterThanOrEqual(8 * 60); // >= 08:00
+          expect(minutes).toBeLessThan(18 * 60); // < 18:00
+        }
+      });
+    });
+
+    it("should exclude times at or after activity end hour", () => {
+      // System time: 10:00, interval: 60, activity 08:00-14:00
+      // Anchor: now -> candidates: 11:00, 12:00, 13:00, 14:00 (at endHour, breaks)
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 60,
+        startHour: "08:00",
+        endHour: "14:00",
+      });
+
+      const todayTimes = result.filter((t) => t.getDate() === 15);
+      todayTimes.forEach((time) => {
+        const minutes = time.getHours() * 60 + time.getMinutes();
+        expect(minutes).toBeLessThan(14 * 60); // < 14:00
+      });
+
+      // Should have exactly 3 today times: 11:00, 12:00, 13:00
+      expect(todayTimes.length).toBe(3);
+    });
+
+    it("should only include future times (not equal to now)", () => {
+      // System time: 10:00, anchor now, interval 60
+      // 10:00+60=11:00 is the first candidate, which is future -> included
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 60,
+      });
+
+      const now = new Date("2024-06-15T10:00:00");
+      result.forEach((time) => {
+        expect(time.getTime()).toBeGreaterThan(now.getTime());
+      });
+    });
+
+    // --- Unlimited mode test ---
+
+    it("should generate times without limit when maxNotifications is 0 (unlimited)", () => {
+      // System time: 10:00, interval: 60, activity 08:00-18:00
+      // Today: 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00 (7 times)
+      // Tomorrow: 08:00, 09:00, ..., 17:00 (10 times)
+      // Total: 17 times
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 0,
+        notificationsSinceLastDrink: 0,
+        intervalMinutes: 60,
+      });
+
+      expect(result.length).toBe(17);
+    });
+
+    it("should generate times for both today and tomorrow in unlimited mode", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 0,
+        intervalMinutes: 60,
+      });
+
+      const todayTimes = result.filter((t) => t.getDate() === 15);
+      const tomorrowTimes = result.filter((t) => t.getDate() === 16);
+
+      expect(todayTimes.length).toBeGreaterThan(0);
+      expect(tomorrowTimes.length).toBeGreaterThan(0);
+    });
+
+    // --- Safety cap test ---
+
+    it("should not exceed step=1000 safety cap in while loop", () => {
+      // Use a very small interval (1 minute) but a wide activity window
+      // to stress-test the safety cap. With interval=1 and 08:00-18:00,
+      // there are 600 possible minutes, well under 1000. But let's verify
+      // the function terminates and produces a reasonable result.
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 1,
+        startHour: "08:00",
+        endHour: "18:00",
+        maxNotifications: 0,
+      });
+
+      // The function should complete without hanging.
+      // Today from 10:01 to 17:59 = up to 479 one-minute intervals
+      // Plus tomorrow 08:00 to 17:59 = 600 one-minute intervals
+      // Total should be well-defined and finite
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(1079); // theoretical max
+    });
+
+    it("should stop at step=1000 even with extreme parameters", () => {
+      // Very tiny interval ensures many steps. The while loop condition
+      // is `times.length < remaining && step < 1000`, so step stops at 999.
+      // With maxNotifications=0, remaining=Infinity, the step cap is the limiter.
+      // Interval=1 min means from 10:00 anchor, steps go 10:01, 10:02, ...
+      // up to step 999 or end of day, whichever comes first.
+      // For today, 10:00 + 999 min = 26:39 which is past midnight, so
+      // the loop breaks when candidate is no longer same day.
+      // The key assertion: it terminates and doesn't hang.
+      const startTime = Date.now();
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 1,
+        maxNotifications: 0,
+        startHour: "00:00",
+        endHour: "23:59",
+      });
+      const elapsed = Date.now() - startTime;
+
+      // Should terminate quickly (well under 1 second)
+      expect(elapsed).toBeLessThan(1000);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    // --- Tomorrow scheduling tests ---
+
+    it("should schedule tomorrow times starting from startHour", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 120,
+        maxNotifications: 0,
+      });
+
+      const tomorrowTimes = result.filter((t) => t.getDate() === 16);
+
+      if (tomorrowTimes.length > 0) {
+        // Tomorrow should start from startHour (08:00)
+        expect(tomorrowTimes[0].getHours()).toBe(8);
+        expect(tomorrowTimes[0].getMinutes()).toBe(0);
+      }
+    });
+
+    it("should not schedule tomorrow times beyond remaining limit", () => {
+      // maxNotifications=1, notificationsSinceLastDrink=0 -> remaining=1
+      // Should only schedule 1 notification total (today)
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        maxNotifications: 1,
+        notificationsSinceLastDrink: 0,
+        intervalMinutes: 60,
+      });
+
+      expect(result.length).toBe(1);
+    });
+
+    // --- Edge case: current time near end of activity hours ---
+
+    it("should handle current time near end of activity hours", () => {
+      // Set time to 17:30, activity ends at 18:00
+      jest.setSystemTime(new Date("2024-06-15T17:30:00"));
+
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 60,
+        startHour: "08:00",
+        endHour: "18:00",
+      });
+
+      // Today: anchor at 17:30, +60min = 18:30 which is past endHour -> 0 today
+      // Tomorrow: 08:00, 09:00, ..., 17:00 -> 10 times
+      const todayTimes = result.filter((t) => t.getDate() === 15);
+      const tomorrowTimes = result.filter((t) => t.getDate() === 16);
+
+      expect(todayTimes.length).toBe(0);
+      expect(tomorrowTimes.length).toBe(10);
+    });
+
+    it("should handle current time before activity start", () => {
+      // Set time to 06:00, activity starts at 08:00
+      jest.setSystemTime(new Date("2024-06-15T06:00:00"));
+
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 60,
+        startHour: "08:00",
+        endHour: "18:00",
+      });
+
+      // Anchor is now (06:00), first candidate 07:00 is before startHour -> excluded
+      // 08:00 is within activity hours and in the future -> included
+      // Then 09:00, 10:00, ..., 17:00
+      const todayTimes = result.filter((t) => t.getDate() === 15);
+      expect(todayTimes.length).toBeGreaterThan(0);
+      expect(todayTimes[0].getHours()).toBe(8);
+    });
+
+    // --- Interval spacing verification ---
+
+    it("should space notifications by the correct interval", () => {
+      const result = calculateSmartNotificationTimes({
+        ...defaultParams,
+        intervalMinutes: 90,
+        lastDrinkTimestamp: "2024-06-15T09:00:00",
+        maxNotifications: 0,
+      });
+
+      // Anchor: 09:00, interval: 90 min
+      // Candidates: 10:30, 12:00, 13:30, 15:00, 16:30
+      const todayTimes = result.filter((t) => t.getDate() === 15);
+      expect(todayTimes.length).toBeGreaterThan(0);
+
+      expect(todayTimes[0].getHours()).toBe(10);
+      expect(todayTimes[0].getMinutes()).toBe(30);
+
+      if (todayTimes.length > 1) {
+        expect(todayTimes[1].getHours()).toBe(12);
+        expect(todayTimes[1].getMinutes()).toBe(0);
+      }
+    });
+  });
+});

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -192,6 +192,190 @@ export function calculateNotificationTimes(
   return times;
 }
 
+export interface SmartScheduleParams {
+  intervalMinutes: number;
+  startHour: string; // "HH:mm" format
+  endHour: string; // "HH:mm" format
+  lastDrinkTimestamp: string | null;
+  maxNotifications: number; // 0 = unlimited
+  notificationsSinceLastDrink: number;
+}
+
+/**
+ * Calculates smart notification times anchored to the last drink timestamp.
+ * Respects activity hours and max notification limits.
+ */
+export function calculateSmartNotificationTimes(
+  params: SmartScheduleParams
+): Date[] {
+  const {
+    intervalMinutes,
+    startHour,
+    endHour,
+    lastDrinkTimestamp,
+    maxNotifications,
+    notificationsSinceLastDrink,
+  } = params;
+
+  if (!isValidTimeFormat(startHour) || !isValidTimeFormat(endHour)) {
+    logWarning("Invalid time format for smart notification scheduling", {
+      operation: "calculateSmartNotificationTimes",
+      component: "NotificationService",
+      data: { startHour, endHour },
+    });
+    return [];
+  }
+
+  const [startH, startM] = startHour.split(":").map(Number);
+  const [endH, endM] = endHour.split(":").map(Number);
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  if (endMinutes <= startMinutes) {
+    logWarning("Overnight schedule not supported for smart notifications", {
+      operation: "calculateSmartNotificationTimes",
+      component: "NotificationService",
+      data: { startHour, endHour },
+    });
+    return [];
+  }
+
+  // Calculate remaining notifications allowed
+  const remaining =
+    maxNotifications === 0
+      ? Infinity
+      : maxNotifications - notificationsSinceLastDrink;
+
+  if (remaining <= 0) {
+    return [];
+  }
+
+  const now = dayjs();
+  const times: Date[] = [];
+
+  // Determine anchor: lastDrinkTimestamp if today, otherwise now
+  let anchor: dayjs.Dayjs;
+  if (lastDrinkTimestamp) {
+    const lastDrink = dayjs(lastDrinkTimestamp);
+    if (lastDrink.isSame(now, "day")) {
+      anchor = lastDrink;
+    } else {
+      anchor = now;
+    }
+  } else {
+    anchor = now;
+  }
+
+  // Generate times for today and tomorrow
+  for (let dayOffset = 0; dayOffset < 2; dayOffset++) {
+    const baseDate = now.add(dayOffset, "day").startOf("day");
+
+    if (dayOffset === 0) {
+      // Today: schedule from anchor + interval increments
+      let step = 1;
+      while (times.length < remaining) {
+        const candidate = anchor.add(step * intervalMinutes, "minute");
+
+        // Stop if candidate is past today
+        if (!candidate.isSame(now, "day")) {
+          break;
+        }
+
+        const candidateMinutes = candidate.hour() * 60 + candidate.minute();
+
+        // Must be within activity hours and in the future
+        if (
+          candidateMinutes >= startMinutes &&
+          candidateMinutes < endMinutes &&
+          candidate.toDate() > new Date()
+        ) {
+          times.push(candidate.toDate());
+        }
+
+        // If candidate is past end hour, stop for today
+        if (candidateMinutes >= endMinutes) {
+          break;
+        }
+
+        step++;
+      }
+    } else {
+      // Tomorrow: start from startHour, continue with interval
+      let currentMinutes = startMinutes;
+
+      while (currentMinutes < endMinutes && times.length < remaining) {
+        const hours = Math.floor(currentMinutes / 60);
+        const minutes = currentMinutes % 60;
+        const notificationTime = baseDate
+          .hour(hours)
+          .minute(minutes)
+          .toDate();
+
+        if (notificationTime > new Date()) {
+          times.push(notificationTime);
+        }
+
+        currentMinutes += intervalMinutes;
+      }
+    }
+  }
+
+  return times;
+}
+
+/**
+ * Schedules smart notifications using the hybrid algorithm.
+ * Returns the count of scheduled notifications.
+ */
+export async function scheduleSmartNotifications(
+  params: SmartScheduleParams & { title: string; body: string }
+): Promise<{ ids: string[]; count: number }> {
+  try {
+    await cancelAllNotifications();
+
+    const times = calculateSmartNotificationTimes(params);
+    const notificationIds: string[] = [];
+
+    for (const time of times) {
+      const id = await Notifications.scheduleNotificationAsync({
+        content: {
+          title: params.title,
+          body: params.body,
+          data: { action: NOTIFICATION_ACTION_OPEN_HOME },
+          sound: true,
+          ...(Platform.OS === "android" && {
+            channelId: NOTIFICATION_CHANNEL_ID,
+          }),
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+          date: time,
+        },
+      });
+
+      notificationIds.push(id);
+    }
+
+    logInfo("Smart notifications scheduled", {
+      operation: "scheduleSmartNotifications",
+      component: "NotificationService",
+      data: {
+        count: notificationIds.length,
+        intervalMinutes: params.intervalMinutes,
+        maxNotifications: params.maxNotifications,
+      },
+    });
+
+    return { ids: notificationIds, count: notificationIds.length };
+  } catch (error) {
+    logError(error, {
+      operation: "scheduleSmartNotifications",
+      component: "NotificationService",
+    });
+    return { ids: [], count: 0 };
+  }
+}
+
 /**
  * Schedules recurring notifications within activity hours
  */

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -1,0 +1,271 @@
+/**
+ * Notification service for scheduling water drinking reminders
+ */
+
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+import dayjs from "dayjs";
+import { logError, logInfo, logWarning } from "@/utils/errorLogging";
+import { isValidTimeFormat } from "@/utils/validation";
+import {
+  NOTIFICATION_CHANNEL_ID,
+  NOTIFICATION_CHANNEL_NAME,
+} from "@/constants/notifications";
+
+// Configure notification handler
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+export type PermissionStatus = "granted" | "denied" | "undetermined";
+
+export interface NotificationScheduleParams {
+  intervalMinutes: number;
+  startHour: string; // "HH:mm" format
+  endHour: string; // "HH:mm" format
+  title: string;
+  body: string;
+}
+
+/**
+ * Requests notification permissions from the user
+ */
+export async function requestPermissions(): Promise<PermissionStatus> {
+  try {
+    const { status: existingStatus } =
+      await Notifications.getPermissionsAsync();
+
+    if (existingStatus === "granted") {
+      return "granted";
+    }
+
+    const { status } = await Notifications.requestPermissionsAsync();
+
+    logInfo("Notification permission request result", {
+      operation: "requestPermissions",
+      component: "NotificationService",
+      data: { status },
+    });
+
+    return status as PermissionStatus;
+  } catch (error) {
+    logError(error, {
+      operation: "requestPermissions",
+      component: "NotificationService",
+    });
+    return "denied";
+  }
+}
+
+/**
+ * Gets current notification permission status
+ */
+export async function getPermissionStatus(): Promise<PermissionStatus> {
+  try {
+    const { status } = await Notifications.getPermissionsAsync();
+    return status as PermissionStatus;
+  } catch (error) {
+    logError(error, {
+      operation: "getPermissionStatus",
+      component: "NotificationService",
+    });
+    return "undetermined";
+  }
+}
+
+/**
+ * Sets up Android notification channel
+ */
+export async function setupNotificationChannel(): Promise<void> {
+  if (Platform.OS === "android") {
+    try {
+      await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
+        name: NOTIFICATION_CHANNEL_NAME,
+        importance: Notifications.AndroidImportance.HIGH,
+        vibrationPattern: [0, 250, 250, 250],
+        lightColor: "#3b82f6",
+      });
+    } catch (error) {
+      logError(error, {
+        operation: "setupNotificationChannel",
+        component: "NotificationService",
+      });
+    }
+  }
+}
+
+/**
+ * Calculates the next notification times within activity hours
+ */
+export function calculateNotificationTimes(
+  intervalMinutes: number,
+  startHour: string,
+  endHour: string
+): Date[] {
+  if (!isValidTimeFormat(startHour) || !isValidTimeFormat(endHour)) {
+    logWarning("Invalid time format for notification scheduling", {
+      operation: "calculateNotificationTimes",
+      component: "NotificationService",
+      data: { startHour, endHour },
+    });
+    return [];
+  }
+
+  const times: Date[] = [];
+  const now = dayjs();
+
+  // Parse start and end hours
+  const [startH, startM] = startHour.split(":").map(Number);
+  const [endH, endM] = endHour.split(":").map(Number);
+
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  // Calculate notification times for today and tomorrow
+  for (let dayOffset = 0; dayOffset < 2; dayOffset++) {
+    const baseDate = now.add(dayOffset, "day").startOf("day");
+
+    // Start from activity start time
+    let currentMinutes = startMinutes;
+
+    // If today, start from the next interval after now
+    if (dayOffset === 0) {
+      const nowMinutes = now.hour() * 60 + now.minute();
+      if (nowMinutes >= startMinutes) {
+        // Find next interval time after now
+        const intervalsSinceStart = Math.ceil(
+          (nowMinutes - startMinutes) / intervalMinutes
+        );
+        currentMinutes = startMinutes + intervalsSinceStart * intervalMinutes;
+      }
+    }
+
+    // Generate times within activity hours
+    while (currentMinutes < endMinutes) {
+      const hours = Math.floor(currentMinutes / 60);
+      const minutes = currentMinutes % 60;
+      const notificationTime = baseDate.hour(hours).minute(minutes).toDate();
+
+      // Only add future times
+      if (notificationTime > new Date()) {
+        times.push(notificationTime);
+      }
+
+      currentMinutes += intervalMinutes;
+    }
+  }
+
+  return times;
+}
+
+/**
+ * Schedules recurring notifications within activity hours
+ */
+export async function scheduleNotifications(
+  params: NotificationScheduleParams
+): Promise<string[]> {
+  try {
+    // Cancel existing notifications first
+    await cancelAllNotifications();
+
+    const times = calculateNotificationTimes(
+      params.intervalMinutes,
+      params.startHour,
+      params.endHour
+    );
+
+    const notificationIds: string[] = [];
+
+    for (const time of times) {
+      const id = await Notifications.scheduleNotificationAsync({
+        content: {
+          title: params.title,
+          body: params.body,
+          data: { action: "open_home" },
+          sound: true,
+          ...(Platform.OS === "android" && {
+            channelId: NOTIFICATION_CHANNEL_ID,
+          }),
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+          date: time,
+        },
+      });
+
+      notificationIds.push(id);
+    }
+
+    logInfo("Notifications scheduled", {
+      operation: "scheduleNotifications",
+      component: "NotificationService",
+      data: { count: notificationIds.length, intervalMinutes: params.intervalMinutes },
+    });
+
+    return notificationIds;
+  } catch (error) {
+    logError(error, {
+      operation: "scheduleNotifications",
+      component: "NotificationService",
+    });
+    return [];
+  }
+}
+
+/**
+ * Cancels all scheduled notifications
+ */
+export async function cancelAllNotifications(): Promise<void> {
+  try {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+
+    logInfo("All notifications cancelled", {
+      operation: "cancelAllNotifications",
+      component: "NotificationService",
+    });
+  } catch (error) {
+    logError(error, {
+      operation: "cancelAllNotifications",
+      component: "NotificationService",
+    });
+  }
+}
+
+/**
+ * Gets all scheduled notifications (for debugging)
+ */
+export async function getScheduledNotifications(): Promise<
+  Notifications.NotificationRequest[]
+> {
+  try {
+    return await Notifications.getAllScheduledNotificationsAsync();
+  } catch (error) {
+    logError(error, {
+      operation: "getScheduledNotifications",
+      component: "NotificationService",
+    });
+    return [];
+  }
+}
+
+/**
+ * Adds listener for notification responses (when user taps notification)
+ */
+export function addNotificationResponseListener(
+  callback: (response: Notifications.NotificationResponse) => void
+): Notifications.EventSubscription {
+  return Notifications.addNotificationResponseReceivedListener(callback);
+}
+
+/**
+ * Adds listener for received notifications (when notification arrives)
+ */
+export function addNotificationReceivedListener(
+  callback: (notification: Notifications.Notification) => void
+): Notifications.EventSubscription {
+  return Notifications.addNotificationReceivedListener(callback);
+}

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -10,7 +10,9 @@ import { isValidTimeFormat } from "@/utils/validation";
 import {
   NOTIFICATION_CHANNEL_ID,
   NOTIFICATION_CHANNEL_NAME,
+  NOTIFICATION_ACTION_OPEN_HOME,
 } from "@/constants/notifications";
+import i18n from "@/plugins/i18n";
 
 // Configure notification handler
 Notifications.setNotificationHandler({
@@ -29,6 +31,17 @@ export interface NotificationScheduleParams {
   endHour: string; // "HH:mm" format
   title: string;
   body: string;
+}
+
+/**
+ * Gets the localized notification content (title and body) for reminder notifications.
+ * This helper centralizes notification content retrieval to avoid duplication.
+ */
+export function getNotificationContent(): { title: string; body: string } {
+  return {
+    title: i18n.t("reminderTitle", { ns: "notifications" }),
+    body: i18n.t("reminderBody", { ns: "notifications" }),
+  };
 }
 
 /**
@@ -125,6 +138,16 @@ export function calculateNotificationTimes(
   const startMinutes = startH * 60 + startM;
   const endMinutes = endH * 60 + endM;
 
+  // Handle overnight schedule edge case (e.g., endHour < startHour like 22:00 to 06:00)
+  if (endMinutes <= startMinutes) {
+    logWarning("Overnight schedule detected - end hour is before or equal to start hour. Notifications will not be scheduled for overnight periods.", {
+      operation: "calculateNotificationTimes",
+      component: "NotificationService",
+      data: { startHour, endHour, startMinutes, endMinutes },
+    });
+    return [];
+  }
+
   // Calculate notification times for today and tomorrow
   for (let dayOffset = 0; dayOffset < 2; dayOffset++) {
     const baseDate = now.add(dayOffset, "day").startOf("day");
@@ -185,7 +208,7 @@ export async function scheduleNotifications(
         content: {
           title: params.title,
           body: params.body,
-          data: { action: "open_home" },
+          data: { action: NOTIFICATION_ACTION_OPEN_HOME },
           sound: true,
           ...(Platform.OS === "android" && {
             channelId: NOTIFICATION_CHANNEL_ID,

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -9,19 +9,24 @@ import { logError, logInfo, logWarning } from "@/utils/errorLogging";
 import { isValidTimeFormat } from "@/utils/validation";
 import {
   NOTIFICATION_CHANNEL_ID,
-  NOTIFICATION_CHANNEL_NAME,
   NOTIFICATION_ACTION_OPEN_HOME,
+  NOTIFICATION_SOUND_ENABLED,
 } from "@/constants/notifications";
 import i18n from "@/plugins/i18n";
 
-// Configure notification handler
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: true,
-    shouldSetBadge: false,
-  }),
-});
+/**
+ * Initializes the notification handler. Must be called before scheduling notifications.
+ * Separated from module scope to avoid side effects on import.
+ */
+export function initializeNotificationHandler(): void {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowAlert: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+    }),
+  });
+}
 
 export type PermissionStatus = "granted" | "denied" | "undetermined";
 
@@ -36,6 +41,10 @@ export interface NotificationScheduleParams {
 /**
  * Gets the localized notification content (title and body) for reminder notifications.
  * This helper centralizes notification content retrieval to avoid duplication.
+ *
+ * Note: Content is resolved at schedule time using the current language.
+ * If the user changes language after scheduling, already-scheduled notifications
+ * will still display in the previous language until they are rescheduled.
  */
 export function getNotificationContent(): { title: string; body: string } {
   return {
@@ -100,11 +109,13 @@ export async function getPermissionStatus(): Promise<PermissionStatus> {
  * Sets up Android notification channel
  */
 export async function setupNotificationChannel(): Promise<void> {
+  initializeNotificationHandler();
+
   if (Platform.OS === "android") {
     try {
       await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
-        name: NOTIFICATION_CHANNEL_NAME,
-        description: "Reminders to stay hydrated throughout the day",
+        name: i18n.t("channelName", { ns: "notifications" }),
+        description: i18n.t("channelDescription", { ns: "notifications" }),
         importance: Notifications.AndroidImportance.HIGH,
         vibrationPattern: [0, 250, 250, 250],
         lightColor: "#3b82f6",
@@ -257,7 +268,7 @@ export function calculateSmartNotificationTimes(
   let anchor: dayjs.Dayjs;
   if (lastDrinkTimestamp) {
     const lastDrink = dayjs(lastDrinkTimestamp);
-    if (lastDrink.isSame(now, "day")) {
+    if (lastDrink.isValid() && lastDrink.isSame(now, "day")) {
       anchor = lastDrink;
     } else {
       anchor = now;
@@ -273,7 +284,7 @@ export function calculateSmartNotificationTimes(
     if (dayOffset === 0) {
       // Today: schedule from anchor + interval increments
       let step = 1;
-      while (times.length < remaining) {
+      while (times.length < remaining && step < 1000) {
         const candidate = anchor.add(step * intervalMinutes, "minute");
 
         // Stop if candidate is past today
@@ -342,7 +353,7 @@ export async function scheduleSmartNotifications(
           title: params.title,
           body: params.body,
           data: { action: NOTIFICATION_ACTION_OPEN_HOME },
-          sound: true,
+          sound: NOTIFICATION_SOUND_ENABLED,
           ...(Platform.OS === "android" && {
             channelId: NOTIFICATION_CHANNEL_ID,
           }),
@@ -400,7 +411,7 @@ export async function scheduleNotifications(
           title: params.title,
           body: params.body,
           data: { action: NOTIFICATION_ACTION_OPEN_HOME },
-          sound: true,
+          sound: NOTIFICATION_SOUND_ENABLED,
           ...(Platform.OS === "android" && {
             channelId: NOTIFICATION_CHANNEL_ID,
           }),

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -56,7 +56,13 @@ export async function requestPermissions(): Promise<PermissionStatus> {
       return "granted";
     }
 
-    const { status } = await Notifications.requestPermissionsAsync();
+    const { status } = await Notifications.requestPermissionsAsync({
+      ios: {
+        allowAlert: true,
+        allowSound: true,
+        allowBadge: false,
+      },
+    });
 
     logInfo("Notification permission request result", {
       operation: "requestPermissions",
@@ -98,6 +104,7 @@ export async function setupNotificationChannel(): Promise<void> {
     try {
       await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
         name: NOTIFICATION_CHANNEL_NAME,
+        description: "Reminders to stay hydrated throughout the day",
         importance: Notifications.AndroidImportance.HIGH,
         vibrationPattern: [0, 250, 250, 250],
         lightColor: "#3b82f6",

--- a/stores/notifications.ts
+++ b/stores/notifications.ts
@@ -1,0 +1,268 @@
+/**
+ * Zustand store for notification settings management
+ */
+
+import { create } from "zustand";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { logError, logWarning } from "@/utils/errorLogging";
+import {
+  requestPermissions as requestNotificationPermissions,
+  getPermissionStatus,
+  scheduleNotifications,
+  cancelAllNotifications,
+  setupNotificationChannel,
+  PermissionStatus,
+} from "@/services/notificationService";
+import {
+  NOTIFICATIONS_STORAGE_KEY,
+  DEFAULT_REMINDER_INTERVAL,
+  DEFAULT_REMINDERS_ENABLED,
+  REMINDER_INTERVALS,
+  ReminderInterval,
+} from "@/constants/notifications";
+
+type NotificationsState = {
+  enabled: boolean;
+  intervalMinutes: ReminderInterval;
+  permissionStatus: PermissionStatus;
+  lastScheduledTime: string | null;
+};
+
+type NotificationsActions = {
+  fetchOrInitData: () => Promise<void>;
+  setEnabled: (enabled: boolean) => Promise<void>;
+  setInterval: (intervalMinutes: ReminderInterval) => Promise<void>;
+  requestPermissions: () => Promise<PermissionStatus>;
+  checkPermissions: () => Promise<PermissionStatus>;
+  scheduleReminders: (
+    startHour: string,
+    endHour: string,
+    title: string,
+    body: string
+  ) => Promise<void>;
+  cancelReminders: () => Promise<void>;
+  reset: () => Promise<void>;
+};
+
+const initialState: NotificationsState = {
+  enabled: DEFAULT_REMINDERS_ENABLED,
+  intervalMinutes: DEFAULT_REMINDER_INTERVAL,
+  permissionStatus: "undetermined",
+  lastScheduledTime: null,
+};
+
+export const useNotificationsStore = create<
+  NotificationsState & NotificationsActions
+>((set, get) => ({
+  ...initialState,
+
+  fetchOrInitData: async () => {
+    try {
+      // Setup notification channel for Android
+      await setupNotificationChannel();
+
+      // Check current permission status
+      const permissionStatus = await getPermissionStatus();
+
+      const data = await AsyncStorage.getItem(NOTIFICATIONS_STORAGE_KEY);
+
+      if (data !== null) {
+        const parsedData = JSON.parse(data);
+
+        if (typeof parsedData === "object" && parsedData !== null) {
+          const validatedData = { ...initialState };
+
+          // Validate enabled
+          if (typeof parsedData.enabled === "boolean") {
+            validatedData.enabled = parsedData.enabled;
+          }
+
+          // Validate interval
+          if (
+            typeof parsedData.intervalMinutes === "number" &&
+            REMINDER_INTERVALS.includes(
+              parsedData.intervalMinutes as ReminderInterval
+            )
+          ) {
+            validatedData.intervalMinutes = parsedData.intervalMinutes;
+          }
+
+          // Validate lastScheduledTime
+          if (typeof parsedData.lastScheduledTime === "string") {
+            validatedData.lastScheduledTime = parsedData.lastScheduledTime;
+          }
+
+          set({ ...validatedData, permissionStatus });
+        } else {
+          logWarning("Invalid notifications data structure, reinitializing", {
+            operation: "fetchOrInitData",
+            component: "NotificationsStore",
+          });
+          await AsyncStorage.setItem(
+            NOTIFICATIONS_STORAGE_KEY,
+            JSON.stringify(initialState)
+          );
+          set({ ...initialState, permissionStatus });
+        }
+      } else {
+        await AsyncStorage.setItem(
+          NOTIFICATIONS_STORAGE_KEY,
+          JSON.stringify(initialState)
+        );
+        set({ ...initialState, permissionStatus });
+      }
+    } catch (error) {
+      logError(error, {
+        operation: "fetchOrInitData",
+        component: "NotificationsStore",
+      });
+      set(initialState);
+
+      try {
+        await AsyncStorage.setItem(
+          NOTIFICATIONS_STORAGE_KEY,
+          JSON.stringify(initialState)
+        );
+      } catch (storageError) {
+        logError(storageError, {
+          operation: "fetchOrInitData - recovery",
+          component: "NotificationsStore",
+        });
+      }
+    }
+  },
+
+  setEnabled: async (enabled: boolean) => {
+    try {
+      set({ enabled });
+
+      const currentState = get();
+      const stateToSave = {
+        enabled,
+        intervalMinutes: currentState.intervalMinutes,
+        lastScheduledTime: currentState.lastScheduledTime,
+      };
+
+      await AsyncStorage.setItem(
+        NOTIFICATIONS_STORAGE_KEY,
+        JSON.stringify(stateToSave)
+      );
+
+      if (!enabled) {
+        await cancelAllNotifications();
+      }
+    } catch (error) {
+      logError(error, {
+        operation: "setEnabled",
+        component: "NotificationsStore",
+        data: { enabled },
+      });
+    }
+  },
+
+  setInterval: async (intervalMinutes: ReminderInterval) => {
+    try {
+      set({ intervalMinutes });
+
+      const currentState = get();
+      const stateToSave = {
+        enabled: currentState.enabled,
+        intervalMinutes,
+        lastScheduledTime: currentState.lastScheduledTime,
+      };
+
+      await AsyncStorage.setItem(
+        NOTIFICATIONS_STORAGE_KEY,
+        JSON.stringify(stateToSave)
+      );
+    } catch (error) {
+      logError(error, {
+        operation: "setInterval",
+        component: "NotificationsStore",
+        data: { intervalMinutes },
+      });
+    }
+  },
+
+  requestPermissions: async () => {
+    const status = await requestNotificationPermissions();
+    set({ permissionStatus: status });
+    return status;
+  },
+
+  checkPermissions: async () => {
+    const status = await getPermissionStatus();
+    set({ permissionStatus: status });
+    return status;
+  },
+
+  scheduleReminders: async (
+    startHour: string,
+    endHour: string,
+    title: string,
+    body: string
+  ) => {
+    try {
+      const { enabled, intervalMinutes, permissionStatus } = get();
+
+      if (!enabled || permissionStatus !== "granted") {
+        return;
+      }
+
+      await scheduleNotifications({
+        intervalMinutes,
+        startHour,
+        endHour,
+        title,
+        body,
+      });
+
+      set({ lastScheduledTime: new Date().toISOString() });
+
+      // Update storage
+      const currentState = get();
+      const stateToSave = {
+        enabled: currentState.enabled,
+        intervalMinutes: currentState.intervalMinutes,
+        lastScheduledTime: currentState.lastScheduledTime,
+      };
+      await AsyncStorage.setItem(
+        NOTIFICATIONS_STORAGE_KEY,
+        JSON.stringify(stateToSave)
+      );
+    } catch (error) {
+      logError(error, {
+        operation: "scheduleReminders",
+        component: "NotificationsStore",
+      });
+    }
+  },
+
+  cancelReminders: async () => {
+    try {
+      await cancelAllNotifications();
+      set({ lastScheduledTime: null });
+    } catch (error) {
+      logError(error, {
+        operation: "cancelReminders",
+        component: "NotificationsStore",
+      });
+    }
+  },
+
+  reset: async () => {
+    try {
+      await cancelAllNotifications();
+      set(initialState);
+      await AsyncStorage.setItem(
+        NOTIFICATIONS_STORAGE_KEY,
+        JSON.stringify(initialState)
+      );
+    } catch (error) {
+      logError(error, {
+        operation: "reset",
+        component: "NotificationsStore",
+      });
+    }
+  },
+}));

--- a/stores/notifications.ts
+++ b/stores/notifications.ts
@@ -21,26 +21,78 @@ import {
   ReminderInterval,
 } from "@/constants/notifications";
 
+/**
+ * State shape for the notifications store
+ */
 type NotificationsState = {
+  /** Whether push notification reminders are enabled */
   enabled: boolean;
+  /** Interval between reminders in minutes (60, 120, or 180) */
   intervalMinutes: ReminderInterval;
+  /** Current notification permission status from the OS */
   permissionStatus: PermissionStatus;
+  /** ISO timestamp of when notifications were last scheduled, or null if never */
   lastScheduledTime: string | null;
 };
 
+/**
+ * Actions available on the notifications store
+ */
 type NotificationsActions = {
+  /**
+   * Initializes the store by loading persisted data from AsyncStorage
+   * and setting up the Android notification channel.
+   * Should be called on app startup.
+   */
   fetchOrInitData: () => Promise<void>;
+  /**
+   * Enables or disables push notification reminders.
+   * When disabled, cancels all scheduled notifications.
+   * @param enabled - Whether reminders should be enabled
+   */
   setEnabled: (enabled: boolean) => Promise<void>;
+  /**
+   * Sets the interval between reminder notifications.
+   * Does not automatically reschedule notifications - call scheduleReminders after.
+   * @param intervalMinutes - The interval in minutes (must be a valid ReminderInterval)
+   */
   setInterval: (intervalMinutes: ReminderInterval) => Promise<void>;
+  /**
+   * Requests notification permissions from the OS.
+   * Updates the permissionStatus state with the result.
+   * @returns The resulting permission status
+   */
   requestPermissions: () => Promise<PermissionStatus>;
+  /**
+   * Checks the current notification permission status without prompting.
+   * Updates the permissionStatus state with the result.
+   * @returns The current permission status
+   */
   checkPermissions: () => Promise<PermissionStatus>;
+  /**
+   * Schedules reminder notifications within the specified activity hours.
+   * Only schedules if enabled is true and permissionStatus is "granted".
+   * Cancels any existing notifications before scheduling new ones.
+   * @param startHour - Start of activity hours in "HH:mm" format
+   * @param endHour - End of activity hours in "HH:mm" format
+   * @param title - Notification title text
+   * @param body - Notification body text
+   */
   scheduleReminders: (
     startHour: string,
     endHour: string,
     title: string,
     body: string
   ) => Promise<void>;
+  /**
+   * Cancels all scheduled reminder notifications.
+   * Resets lastScheduledTime to null.
+   */
   cancelReminders: () => Promise<void>;
+  /**
+   * Resets the store to initial state.
+   * Cancels all notifications and clears persisted data.
+   */
   reset: () => Promise<void>;
 };
 

--- a/stores/notifications.ts
+++ b/stores/notifications.ts
@@ -9,8 +9,10 @@ import {
   requestPermissions as requestNotificationPermissions,
   getPermissionStatus,
   scheduleNotifications,
+  scheduleSmartNotifications,
   cancelAllNotifications,
   setupNotificationChannel,
+  getScheduledNotifications,
   PermissionStatus,
 } from "@/services/notificationService";
 import {
@@ -19,6 +21,9 @@ import {
   DEFAULT_REMINDERS_ENABLED,
   REMINDER_INTERVALS,
   ReminderInterval,
+  MAX_NOTIFICATION_OPTIONS,
+  MaxNotificationOption,
+  DEFAULT_MAX_NOTIFICATIONS,
 } from "@/constants/notifications";
 
 /**
@@ -33,6 +38,14 @@ type NotificationsState = {
   permissionStatus: PermissionStatus;
   /** ISO timestamp of when notifications were last scheduled, or null if never */
   lastScheduledTime: string | null;
+  /** ISO timestamp of the last time user drank water, or null */
+  lastDrinkTimestamp: string | null;
+  /** Number of notifications fired since last drink */
+  notificationsSinceLastDrink: number;
+  /** Maximum notifications before next drink (0 = unlimited) */
+  maxNotifications: MaxNotificationOption;
+  /** Number of notifications scheduled in the last batch */
+  scheduledCount: number;
 };
 
 /**
@@ -94,6 +107,25 @@ type NotificationsActions = {
    * Cancels all notifications and clears persisted data.
    */
   reset: () => Promise<void>;
+  /**
+   * Called when the user drinks water.
+   * Resets the notification counter, saves timestamp, and reschedules.
+   */
+  onWaterDrunk: (startHour: string, endHour: string) => Promise<void>;
+  /**
+   * Called when a notification is received in the foreground.
+   * Increments the notificationsSinceLastDrink counter.
+   */
+  onNotificationReceived: () => void;
+  /**
+   * Sets the maximum notifications before next drink.
+   */
+  setMaxNotifications: (max: MaxNotificationOption) => Promise<void>;
+  /**
+   * Corrects the notification counter based on scheduled notifications
+   * remaining (used when returning from background).
+   */
+  correctNotificationCount: () => Promise<void>;
 };
 
 const initialState: NotificationsState = {
@@ -101,7 +133,36 @@ const initialState: NotificationsState = {
   intervalMinutes: DEFAULT_REMINDER_INTERVAL,
   permissionStatus: "undetermined",
   lastScheduledTime: null,
+  lastDrinkTimestamp: null,
+  notificationsSinceLastDrink: 0,
+  maxNotifications: DEFAULT_MAX_NOTIFICATIONS,
+  scheduledCount: 0,
 };
+
+/**
+ * Builds the persistable state object from the current store state.
+ * Excludes permissionStatus since it's fetched from OS on init.
+ */
+function getStateToPersist(
+  state: NotificationsState
+): Omit<NotificationsState, "permissionStatus"> {
+  return {
+    enabled: state.enabled,
+    intervalMinutes: state.intervalMinutes,
+    lastScheduledTime: state.lastScheduledTime,
+    lastDrinkTimestamp: state.lastDrinkTimestamp,
+    notificationsSinceLastDrink: state.notificationsSinceLastDrink,
+    maxNotifications: state.maxNotifications,
+    scheduledCount: state.scheduledCount,
+  };
+}
+
+async function persistState(state: NotificationsState): Promise<void> {
+  await AsyncStorage.setItem(
+    NOTIFICATIONS_STORAGE_KEY,
+    JSON.stringify(getStateToPersist(state))
+  );
+}
 
 export const useNotificationsStore = create<
   NotificationsState & NotificationsActions
@@ -144,6 +205,38 @@ export const useNotificationsStore = create<
             validatedData.lastScheduledTime = parsedData.lastScheduledTime;
           }
 
+          // Validate lastDrinkTimestamp (backward compat)
+          if (typeof parsedData.lastDrinkTimestamp === "string") {
+            validatedData.lastDrinkTimestamp = parsedData.lastDrinkTimestamp;
+          }
+
+          // Validate notificationsSinceLastDrink (backward compat)
+          if (
+            typeof parsedData.notificationsSinceLastDrink === "number" &&
+            parsedData.notificationsSinceLastDrink >= 0
+          ) {
+            validatedData.notificationsSinceLastDrink =
+              parsedData.notificationsSinceLastDrink;
+          }
+
+          // Validate maxNotifications (backward compat)
+          if (
+            typeof parsedData.maxNotifications === "number" &&
+            MAX_NOTIFICATION_OPTIONS.includes(
+              parsedData.maxNotifications as MaxNotificationOption
+            )
+          ) {
+            validatedData.maxNotifications = parsedData.maxNotifications;
+          }
+
+          // Validate scheduledCount (backward compat)
+          if (
+            typeof parsedData.scheduledCount === "number" &&
+            parsedData.scheduledCount >= 0
+          ) {
+            validatedData.scheduledCount = parsedData.scheduledCount;
+          }
+
           set({ ...validatedData, permissionStatus });
         } else {
           logWarning("Invalid notifications data structure, reinitializing", {
@@ -152,14 +245,14 @@ export const useNotificationsStore = create<
           });
           await AsyncStorage.setItem(
             NOTIFICATIONS_STORAGE_KEY,
-            JSON.stringify(initialState)
+            JSON.stringify(getStateToPersist(initialState))
           );
           set({ ...initialState, permissionStatus });
         }
       } else {
         await AsyncStorage.setItem(
           NOTIFICATIONS_STORAGE_KEY,
-          JSON.stringify(initialState)
+          JSON.stringify(getStateToPersist(initialState))
         );
         set({ ...initialState, permissionStatus });
       }
@@ -173,7 +266,7 @@ export const useNotificationsStore = create<
       try {
         await AsyncStorage.setItem(
           NOTIFICATIONS_STORAGE_KEY,
-          JSON.stringify(initialState)
+          JSON.stringify(getStateToPersist(initialState))
         );
       } catch (storageError) {
         logError(storageError, {
@@ -189,16 +282,7 @@ export const useNotificationsStore = create<
       set({ enabled });
 
       const currentState = get();
-      const stateToSave = {
-        enabled,
-        intervalMinutes: currentState.intervalMinutes,
-        lastScheduledTime: currentState.lastScheduledTime,
-      };
-
-      await AsyncStorage.setItem(
-        NOTIFICATIONS_STORAGE_KEY,
-        JSON.stringify(stateToSave)
-      );
+      await persistState(currentState);
 
       if (!enabled) {
         await cancelAllNotifications();
@@ -217,16 +301,7 @@ export const useNotificationsStore = create<
       set({ intervalMinutes });
 
       const currentState = get();
-      const stateToSave = {
-        enabled: currentState.enabled,
-        intervalMinutes,
-        lastScheduledTime: currentState.lastScheduledTime,
-      };
-
-      await AsyncStorage.setItem(
-        NOTIFICATIONS_STORAGE_KEY,
-        JSON.stringify(stateToSave)
-      );
+      await persistState(currentState);
     } catch (error) {
       logError(error, {
         operation: "setInterval",
@@ -255,33 +330,37 @@ export const useNotificationsStore = create<
     body: string
   ) => {
     try {
-      const { enabled, intervalMinutes, permissionStatus } = get();
+      const {
+        enabled,
+        intervalMinutes,
+        permissionStatus,
+        lastDrinkTimestamp,
+        notificationsSinceLastDrink,
+        maxNotifications,
+      } = get();
 
       if (!enabled || permissionStatus !== "granted") {
         return;
       }
 
-      await scheduleNotifications({
+      const { count } = await scheduleSmartNotifications({
         intervalMinutes,
         startHour,
         endHour,
+        lastDrinkTimestamp,
+        maxNotifications,
+        notificationsSinceLastDrink,
         title,
         body,
       });
 
-      set({ lastScheduledTime: new Date().toISOString() });
+      set({
+        lastScheduledTime: new Date().toISOString(),
+        scheduledCount: count,
+      });
 
-      // Update storage
       const currentState = get();
-      const stateToSave = {
-        enabled: currentState.enabled,
-        intervalMinutes: currentState.intervalMinutes,
-        lastScheduledTime: currentState.lastScheduledTime,
-      };
-      await AsyncStorage.setItem(
-        NOTIFICATIONS_STORAGE_KEY,
-        JSON.stringify(stateToSave)
-      );
+      await persistState(currentState);
     } catch (error) {
       logError(error, {
         operation: "scheduleReminders",
@@ -293,7 +372,7 @@ export const useNotificationsStore = create<
   cancelReminders: async () => {
     try {
       await cancelAllNotifications();
-      set({ lastScheduledTime: null });
+      set({ lastScheduledTime: null, scheduledCount: 0 });
     } catch (error) {
       logError(error, {
         operation: "cancelReminders",
@@ -308,11 +387,119 @@ export const useNotificationsStore = create<
       set(initialState);
       await AsyncStorage.setItem(
         NOTIFICATIONS_STORAGE_KEY,
-        JSON.stringify(initialState)
+        JSON.stringify(getStateToPersist(initialState))
       );
     } catch (error) {
       logError(error, {
         operation: "reset",
+        component: "NotificationsStore",
+      });
+    }
+  },
+
+  onWaterDrunk: async (startHour: string, endHour: string) => {
+    try {
+      const timestamp = new Date().toISOString();
+      set({
+        lastDrinkTimestamp: timestamp,
+        notificationsSinceLastDrink: 0,
+      });
+
+      const currentState = get();
+      await persistState(currentState);
+
+      // Reschedule with reset counter
+      if (
+        currentState.enabled &&
+        currentState.permissionStatus === "granted"
+      ) {
+        const { getNotificationContent } = await import(
+          "@/services/notificationService"
+        );
+        const { title, body } = getNotificationContent();
+
+        const { count } = await scheduleSmartNotifications({
+          intervalMinutes: currentState.intervalMinutes,
+          startHour,
+          endHour,
+          lastDrinkTimestamp: timestamp,
+          maxNotifications: currentState.maxNotifications,
+          notificationsSinceLastDrink: 0,
+          title,
+          body,
+        });
+
+        set({
+          lastScheduledTime: new Date().toISOString(),
+          scheduledCount: count,
+        });
+
+        const updatedState = get();
+        await persistState(updatedState);
+      }
+    } catch (error) {
+      logError(error, {
+        operation: "onWaterDrunk",
+        component: "NotificationsStore",
+      });
+    }
+  },
+
+  onNotificationReceived: () => {
+    const currentState = get();
+    const newCount = currentState.notificationsSinceLastDrink + 1;
+    set({ notificationsSinceLastDrink: newCount });
+
+    // Persist async (fire and forget)
+    const updatedState = get();
+    persistState(updatedState).catch((error) => {
+      logError(error, {
+        operation: "onNotificationReceived",
+        component: "NotificationsStore",
+      });
+    });
+  },
+
+  setMaxNotifications: async (max: MaxNotificationOption) => {
+    try {
+      set({ maxNotifications: max });
+
+      const currentState = get();
+      await persistState(currentState);
+    } catch (error) {
+      logError(error, {
+        operation: "setMaxNotifications",
+        component: "NotificationsStore",
+        data: { max },
+      });
+    }
+  },
+
+  correctNotificationCount: async () => {
+    try {
+      const currentState = get();
+      if (!currentState.enabled || currentState.scheduledCount === 0) {
+        return;
+      }
+
+      const scheduled = await getScheduledNotifications();
+      const remainingCount = scheduled.length;
+      const fired = currentState.scheduledCount - remainingCount;
+
+      if (fired > 0) {
+        const corrected =
+          currentState.notificationsSinceLastDrink + fired;
+        set({
+          notificationsSinceLastDrink: corrected,
+          scheduledCount: remainingCount,
+        });
+
+        const updatedState = get();
+        await persistState(updatedState);
+      }
+    } catch (error) {
+      logError(error, {
+        operation: "correctNotificationCount",
         component: "NotificationsStore",
       });
     }

--- a/stores/notifications.ts
+++ b/stores/notifications.ts
@@ -13,6 +13,7 @@ import {
   cancelAllNotifications,
   setupNotificationChannel,
   getScheduledNotifications,
+  getNotificationContent,
   PermissionStatus,
 } from "@/services/notificationService";
 import {
@@ -296,6 +297,7 @@ export const useNotificationsStore = create<
     }
   },
 
+  /** Sets the interval. Does NOT reschedule — the caller must call scheduleReminders after. */
   setInterval: async (intervalMinutes: ReminderInterval) => {
     try {
       set({ intervalMinutes });
@@ -373,6 +375,7 @@ export const useNotificationsStore = create<
     try {
       await cancelAllNotifications();
       set({ lastScheduledTime: null, scheduledCount: 0 });
+      await persistState(get());
     } catch (error) {
       logError(error, {
         operation: "cancelReminders",
@@ -413,9 +416,6 @@ export const useNotificationsStore = create<
         currentState.enabled &&
         currentState.permissionStatus === "granted"
       ) {
-        const { getNotificationContent } = await import(
-          "@/services/notificationService"
-        );
         const { title, body } = getNotificationContent();
 
         const { count } = await scheduleSmartNotifications({
@@ -487,6 +487,16 @@ export const useNotificationsStore = create<
       const fired = currentState.scheduledCount - remainingCount;
 
       if (fired > 0) {
+        logWarning("Notification counter drift corrected", {
+          operation: "correctNotificationCount",
+          component: "NotificationsStore",
+          data: {
+            fired,
+            previousCount: currentState.notificationsSinceLastDrink,
+            correctedCount: currentState.notificationsSinceLastDrink + fired,
+          },
+        });
+
         const corrected =
           currentState.notificationsSinceLastDrink + fired;
         set({


### PR DESCRIPTION
## Summary
- Implement local push notifications to remind users to drink water
- Add configurable reminder intervals (1h, 2h, 3h)
- Respect user activity hours (startHour - endHour from settings)
- Handle notification permissions with settings redirect
- Add deep linking when tapping notifications
- Auto-reschedule notifications when app becomes active
- Full EN/PL localization support

## New Files
- `constants/notifications.ts` - Notification constants and types
- `services/notificationService.ts` - Core notification scheduling logic
- `stores/notifications.ts` - Zustand store for notification settings
- `app/(tabs)/setup/reminders.tsx` - Reminders settings screen
- `i18n/en/notifications.json` - English notification text
- `i18n/pl/notifications.json` - Polish notification text

## Modified Files
- `package.json` - Added expo-notifications dependency
- `app.json` - Added expo-notifications plugin
- `app/_layout.tsx` - Notification initialization and deep linking
- `app/(tabs)/setup/_layout.tsx` - Added reminders screen to navigation
- `app/(tabs)/setup/index.tsx` - Added reminders menu item
- `i18n/*/setup.json` - Added reminder-related translations

## Test plan
- [ ] Build with EAS (notifications don't work in Expo Go)
- [ ] Enable reminders and verify permission prompt appears
- [ ] Set different intervals and verify scheduling works
- [ ] Verify notifications only arrive within activity hours
- [ ] Tap notification and verify app opens to home screen
- [ ] Disable reminders and verify no more notifications
- [ ] Run `npm run lint` - passes
- [ ] Run `npm test` - all 107 tests pass

## Notes
This uses **local scheduled notifications** (not Firebase/FCM). No backend or Firebase configuration needed.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)