### PR TITLE
fix: await async widget sync calls to prevent 0ml display

### DIFF
--- a/app/(tabs)/setup/general.tsx
+++ b/app/(tabs)/setup/general.tsx
@@ -48,16 +48,19 @@ export default function GeneralSettings() {
     onboarding.setStatus(value as Status);
   };
 
-  const handleGlassCapacityBlur = (value: string) => {
+  const handleGlassCapacityBlur = async (value: string) => {
     // Sanitize and persist on blur
-    const sanitized = sanitizePositiveNumber(value, String(DEFAULT_GLASS_CAPACITY));
-    setupStore.setGlassCapacity(sanitized);
+    const sanitized = sanitizePositiveNumber(
+      value,
+      String(DEFAULT_GLASS_CAPACITY),
+    );
+    await setupStore.setGlassCapacity(sanitized);
   };
 
-  const handleMinimumWaterBlur = (value: string) => {
+  const handleMinimumWaterBlur = async (value: string) => {
     // Sanitize and persist on blur
     const sanitized = sanitizePositiveNumber(value, String(DEFAULT_DAILY_GOAL));
-    setupStore.setMinimumWater(sanitized);
+    await setupStore.setMinimumWater(sanitized);
   };
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -111,7 +111,7 @@ export default function RootLayout() {
           fetchOrInitWaterData();
           checkAndUnlockAchievements();
           // Sync any changes made from widget while app was in background
-          syncFromWidget();
+          await syncFromWidget();
 
           // Correct notification counter and reschedule when app becomes active
           // Use getState() to get fresh values instead of stale closure values

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -197,7 +197,7 @@ export default function RootLayout() {
       createAutomaticBackup();
 
       // Initialize widget data after stores are loaded
-      initializeWidgetData();
+      await initializeWidgetData();
 
       // Handle deep link that opened the app (only after stores are ready)
       const initialUrl = await Linking.getInitialURL();

--- a/stores/setup.ts
+++ b/stores/setup.ts
@@ -198,14 +198,14 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
     const sanitized = sanitizePositiveNumber(capacity, String(DEFAULT_GLASS_CAPACITY));
     await get().setOption(SetupOptions.GLASS_CAPACITY, sanitized);
     // Sync to widget as glass capacity affects quick add button
-    syncToWidget();
+    await syncToWidget();
   },
   setMinimumWater: async (water: string) => {
     // Sanitize and persist to storage
     const sanitized = sanitizePositiveNumber(water, String(DEFAULT_DAILY_GOAL));
     await get().setOption(SetupOptions.MINIMUM_WATER, sanitized);
     // Sync to widget as daily goal affects progress percentage
-    syncToWidget();
+    await syncToWidget();
   },
   setGlassCapacityTemp: (capacity: string) => {
     // Temporary update without persisting - for editing

--- a/stores/setup.ts
+++ b/stores/setup.ts
@@ -194,18 +194,32 @@ export const useSetupStore = create<SetupState & SetupActions>((set, get) => ({
     quickActions: get()[SetupOptions.QUICK_ACTIONS],
   }),
   setGlassCapacity: async (capacity: string) => {
-    // Sanitize and persist to storage
-    const sanitized = sanitizePositiveNumber(capacity, String(DEFAULT_GLASS_CAPACITY));
-    await get().setOption(SetupOptions.GLASS_CAPACITY, sanitized);
-    // Sync to widget as glass capacity affects quick add button
-    await syncToWidget();
+    try {
+      // Sanitize and persist to storage
+      const sanitized = sanitizePositiveNumber(capacity, String(DEFAULT_GLASS_CAPACITY));
+      await get().setOption(SetupOptions.GLASS_CAPACITY, sanitized);
+      // Sync to widget as glass capacity affects quick add button
+      await syncToWidget();
+    } catch (error) {
+      logError(error, {
+        operation: 'setGlassCapacity',
+        component: 'SetupStore',
+      });
+    }
   },
   setMinimumWater: async (water: string) => {
-    // Sanitize and persist to storage
-    const sanitized = sanitizePositiveNumber(water, String(DEFAULT_DAILY_GOAL));
-    await get().setOption(SetupOptions.MINIMUM_WATER, sanitized);
-    // Sync to widget as daily goal affects progress percentage
-    await syncToWidget();
+    try {
+      // Sanitize and persist to storage
+      const sanitized = sanitizePositiveNumber(water, String(DEFAULT_DAILY_GOAL));
+      await get().setOption(SetupOptions.MINIMUM_WATER, sanitized);
+      // Sync to widget as daily goal affects progress percentage
+      await syncToWidget();
+    } catch (error) {
+      logError(error, {
+        operation: 'setMinimumWater',
+        component: 'SetupStore',
+      });
+    }
   },
   setGlassCapacityTemp: (capacity: string) => {
     // Temporary update without persisting - for editing

--- a/stores/water.ts
+++ b/stores/water.ts
@@ -120,7 +120,7 @@ export const useWaterStore = create<WaterStore>((set, get) => ({
       await AsyncStorage.setItem(storageKey, JSON.stringify(history));
 
       // Sync updated data to home screen widget
-      syncToWidget();
+      await syncToWidget();
     } catch (error) {
       logError(error, {
         operation: 'setWater',


### PR DESCRIPTION
## Summary
- Fixed iOS widget displaying 0ml by properly awaiting async `syncToWidget()` and `initializeWidgetData()` calls
- Added `await` to widget sync calls in `stores/water.ts`, `stores/setup.ts`, and `app/_layout.tsx` to ensure data is written to shared storage before the widget reads it

## Test plan
- [ ] Verify iOS widget shows correct water intake after adding water
- [ ] Verify iOS widget updates when glass capacity or daily goal is changed in settings
- [ ] Verify widget shows correct data on app launch (cold start)
- [ ] Confirm no regressions on Android widget behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)