### PR TITLE
feat: GDPR consent system for ads

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,8 @@
       "supportsTablet": true,
       "bundleIdentifier": "website.ihumbak.hydration",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSUserTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you."
       },
       "icon": {
         "dark": "./assets/images/ios-dark.png",
@@ -49,7 +50,8 @@
         "react-native-google-mobile-ads",
         {
           "androidAppId": "ca-app-pub-7007354971618918~4011715390",
-          "iosAppId": "ca-app-pub-7007354971618918~1874924068"
+          "iosAppId": "ca-app-pub-7007354971618918~1874924068",
+          "delayAppMeasurementInit": true
         }
       ],
       [

--- a/app/(tabs)/setup/index.tsx
+++ b/app/(tabs)/setup/index.tsx
@@ -3,10 +3,12 @@ import { useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { useConsentStore } from "@/stores/consent";
 
 export default function SettingsMenu() {
   const router = useRouter();
-  const { t } = useTranslation("setup");
+  const { t } = useTranslation(["setup", "consent"]);
+  const { privacyOptionsRequired, showPrivacyOptions } = useConsentStore();
 
   const menuItems = [
     {
@@ -33,6 +35,17 @@ export default function SettingsMenu() {
       icon: "download",
       onPress: () => router.push("/(tabs)/setup/backup"),
     },
+    // Only show for EU users who have given consent
+    ...(privacyOptionsRequired
+      ? [
+          {
+            id: "privacy",
+            title: t("consent:privacySettings"),
+            icon: "shield",
+            onPress: showPrivacyOptions,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ import { useOnboardingStore } from "@/stores/onboarding";
 import { useGamificationStore } from "@/stores/gamification";
 import { useBackupStore } from "@/stores/backup";
 import { useNotificationsStore } from "@/stores/notifications";
+import { useConsentStore } from "@/stores/consent";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useNotificationListeners } from "@/hooks/useNotificationListeners";
 import { useActivityHoursRescheduler } from "@/hooks/useActivityHoursRescheduler";
@@ -37,6 +38,7 @@ export default function RootLayout() {
   const { createAutomaticBackup } = useBackupStore();
   const { fetchOrInitData: fetchOrInitNotifications, scheduleReminders } =
     useNotificationsStore();
+  const { initializeConsent } = useConsentStore();
   const [loaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
@@ -56,6 +58,7 @@ export default function RootLayout() {
     fetchOrInitOnboarding,
     fetchOrInitGamification,
     fetchOrInitNotifications,
+    initializeConsent,
     createAutomaticBackup,
     checkAndUnlockAchievements,
   });

--- a/components/ads/Banner.tsx
+++ b/components/ads/Banner.tsx
@@ -5,13 +5,8 @@ import {
   useForeground,
 } from "react-native-google-mobile-ads";
 import React, { useRef } from "react";
-import { Platform, Text } from "react-native";
-
-const ids = {
-  android: "ca-app-pub-7007354971618918/3882663398",
-  ios: "ca-app-pub-7007354971618918/3005971080",
-  default: TestIds.ADAPTIVE_BANNER,
-};
+import { Platform, View } from "react-native";
+import { useConsentStore } from "@/stores/consent";
 
 const adUnitId = __DEV__
   ? TestIds.ADAPTIVE_BANNER
@@ -21,20 +16,23 @@ const adUnitId = __DEV__
 
 export const Banner = () => {
   const bannerRef = useRef<BannerAd>(null);
+  const { isInitialized, canRequestAds, isMobileAdsInitialized } =
+    useConsentStore();
 
   useForeground(() => {
     Platform.OS === "ios" && bannerRef.current?.load();
   });
+
+  // Don't render ads until consent is initialized and we can request ads
+  if (!isInitialized || !canRequestAds || !isMobileAdsInitialized) {
+    return <View />;
+  }
+
   return (
-    <>
-      <BannerAd
-        ref={bannerRef}
-        requestOptions={{
-          requestNonPersonalizedAdsOnly: true,
-        }}
-        unitId={adUnitId}
-        size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
-      />
-    </>
+    <BannerAd
+      ref={bannerRef}
+      unitId={adUnitId}
+      size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
+    />
   );
 };

--- a/constants/consent.ts
+++ b/constants/consent.ts
@@ -1,0 +1,30 @@
+import { AdsConsentStatus } from "react-native-google-mobile-ads";
+
+export const CONSENT_STORAGE_KEY = "consentData";
+
+export enum ConsentInitializationStatus {
+  NOT_STARTED = "NOT_STARTED",
+  IN_PROGRESS = "IN_PROGRESS",
+  COMPLETED = "COMPLETED",
+  FAILED = "FAILED",
+}
+
+export type ConsentState = {
+  status: AdsConsentStatus;
+  canRequestAds: boolean;
+  isInitialized: boolean;
+  initializationStatus: ConsentInitializationStatus;
+  isMobileAdsInitialized: boolean;
+  privacyOptionsRequired: boolean;
+};
+
+export const initialConsentState: Omit<ConsentState, "status"> & {
+  status: AdsConsentStatus | null;
+} = {
+  status: null,
+  canRequestAds: false,
+  isInitialized: false,
+  initializationStatus: ConsentInitializationStatus.NOT_STARTED,
+  isMobileAdsInitialized: false,
+  privacyOptionsRequired: false,
+};

--- a/docs/APP_STORE_TEXTS_PL.md
+++ b/docs/APP_STORE_TEXTS_PL.md
@@ -1,0 +1,87 @@
+# Teksty App Store - Water Tracker Hydration App (PL)
+
+## Tekst promocyjny (max 170 znakow)
+
+```
+Nawadniaj sie z nowym designem, widgetami na ekranie glownym i 11 osiagnieciami do odblokowania. Sledz picie wody, buduj serie i osiagaj cele bez wysilku.
+```
+
+_(155 znakow)_
+
+---
+
+## Opis (max 4000 znakow)
+
+```
+Water Tracker sprawia, ze nawadnianie jest proste, przyjemne i motywujace. Niezaleznie od tego, czy chcesz wybudowac zdrowy nawyk picia wody, czy sledzic dzienna ilosc z precyzja, ta aplikacja daje Ci wszystko, czego potrzebujesz w przejrzystym interfejsie.
+
+PIEKNY PULPIT
+Duzy kolowy pierscien postepu pokazuje Twoje dzienne nawodnienie na pierwszy rzut oka. Obserwuj, jak sie wypelnia w ciagu dnia, zmieniajac kolor na zielony z ptaszkiem, gdy osiagniesz cel. Pasek postepu dnia sledzi Twoje aktywne godziny, abys mogl rownomiernie rozlozyc picie.
+
+ELASTYCZNE DODAWANIE WODY
+Dodawaj wode po swojemu. Uzyj konfigurowalnych przyciskow szybkich akcji dla ulubionych ilosci — szklanka, butelka, puszka lub stworzony przez Ciebie. Potrzebujesz precyzji? Otwierz picker i ustaw dokladna ilosc. Mozesz tez usunac wpisy, jesli cos dodasz przez pomylke.
+
+WIDGETY NA EKRANIE GLOWNYM
+Miej nawadnianie zawsze na widoku dzieki natywnym widgetom na iOS i Androida. Sprawdzaj postep, aktualna serie i cel dzienny bez otwierania aplikacji. Sredni widget pozwala dodac wode jednym dotknieciem, wprost z ekranu glownego.
+
+11 OSIAGNIEC DO ODBLOKOWANIA
+Utrzymuj motywacje dzieki wbudowanemu systemowi osiagniec. Zdobywaj odznaki za pierwsza szlanke, serie 3, 7, 14 i 30 dni, realizacje celow tygodniowych i miesiecznych oraz kamienie milowe 10, 50 i 100 litrow. Powiadomienia w aplikacji swietuja kazde odblokowanie.
+
+SZCZEGOLOWE STATYSTYKI I TRENDY
+Sledz postepy w czasie w widokach tygodniowych, miesiecznych i calkowitych. Sprawdzaj srednie spozycie, laczna konsumpcje, wskaznik realizacji celu i aktualna serie. Analiza trendow porownuje biezacy okres z poprzednim, abys zawsze wiedzial, czy robisz postepy.
+
+INTELIGENTNE PRZYPOMNIENIA
+Ustaw przypomnienia co 1, 2 lub 3 godziny w czasie aktywnych godzin. Kontroluj liczbe powiadomien przed nastepnym piciem. Przypomnienia automatycznie sie przestawiaja po zalogowaniu wody, wiec nigdy nie sa nachalne.
+
+PELNA KONTROLA NAD DANYMI
+Twoje dane naleza do Ciebie. Automatyczne codzienne kopie zapasowe chronia historie. Eksportuj wszystko jako JSON (pelna kopia) lub CSV (do arkuszy kalkulacyjnych). Importuj dane w dowolnym momencie, aby przywrocic lub przeniesc miedzy urzadzeniami.
+
+PELNA PERSONALIZACJA
+Ustaw dzienny cel, pojemnosc szklanki i aktywne godziny. Dodaj do 10 wlasnych przyciskow szybkich akcji z etykietami i ilosciami. Wybierz jezyk, format daty i przelacz wibracje dotykowe. Dostosuj aplikacje do siebie.
+
+PRYWATNOSC NA PIERWSZYM MIEJSCU
+Wszystkie dane pozostaja na Twoim urzadzeniu. Bez konta. Bez wysylania danych na serwery. Tylko Ty i Twoja woda.
+
+Stworzone z miloscia dla ludzi, ktorzy chca pic wiecej wody.
+```
+
+---
+
+## Co nowego w tej wersji
+
+```
+CALKOWICIE NOWY DESIGN
+
+Ta aktualizacja przynosi swiezy, nowoczesny wyglad na kazdym ekranie:
+
+- Nowa paleta kolorow inspirowana oceanem z uspokajacymi odcieniami niebieskiego, zielonego i miety
+- Przeprojektowany kolowy pierscien postepu z cieniem dla efektu premium
+- Nowy system dodawania wody oparty na modalu, zastepujacy stary rzad przyciskow — czysciej i intuicyjniej
+- Dopracowana typografia, odstepy i hierarchia wizualna
+
+WIDGETY NA EKRANIE GLOWNYM
+
+Badz na biezaco bez otwierania aplikacji:
+
+- Widgety iOS w rozmiarze malym i srednim
+- Widget Androida z szybkim przyciskiem dodawania wody
+- Sprawdzaj postep, serie i cel dzienny na pierwszy rzut oka
+- Dodawaj wode jednym dotknieciem z poziomu sredniegio widgetu
+
+DODATKOWE ULEPSZENIA
+
+- Plynniejsze animacje i przejscia
+- Lepsza obsluga dostepnosci
+- Optymalizacja wydajnosci
+- Poprawki bledow i stabilnosci
+```
+
+---
+
+## Slowa kluczowe (max 100 znakow, oddzielone przecinkami)
+
+```
+picie wody,nawadnianie,tracker wody,przypomnienie,cel dzienny,zdrowie,nawyk,seria,widget,hydration
+```
+
+_(99 znakow)_

--- a/hooks/useAppLifecycle.ts
+++ b/hooks/useAppLifecycle.ts
@@ -18,6 +18,7 @@ interface UseAppLifecycleParams {
   fetchOrInitOnboarding: () => Promise<void>;
   fetchOrInitGamification: () => Promise<void>;
   fetchOrInitNotifications: () => Promise<void>;
+  initializeConsent: () => Promise<void>;
   createAutomaticBackup: () => void;
   checkAndUnlockAchievements: () => void;
 }
@@ -28,6 +29,7 @@ export function useAppLifecycle({
   fetchOrInitOnboarding,
   fetchOrInitGamification,
   fetchOrInitNotifications,
+  initializeConsent,
   createAutomaticBackup,
   checkAndUnlockAchievements,
 }: UseAppLifecycleParams) {
@@ -127,6 +129,10 @@ export function useAppLifecycle({
 
     // Initialize app - must wait for stores before handling deep links
     const initializeApp = async () => {
+      // Initialize consent FIRST (before ads SDK)
+      // This must happen before any ad-related code runs
+      await initializeConsent();
+
       // Load all stores first
       await Promise.all([
         fetchOrInitSetup(),

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -6,6 +6,7 @@ import onboarding from "@/i18n/en/onboarding.json";
 import gamification from "@/i18n/en/gamification.json";
 import errors from "@/i18n/en/errors.json";
 import notifications from "@/i18n/en/notifications.json";
+import consent from "@/i18n/en/consent.json";
 
 export default {
   translation,
@@ -16,4 +17,5 @@ export default {
   gamification,
   errors,
   notifications,
+  consent,
 };

--- a/i18n/en/consent.json
+++ b/i18n/en/consent.json
@@ -1,0 +1,8 @@
+{
+  "privacySettings": "Privacy Settings",
+  "manageConsent": "Manage ad preferences",
+  "consentDescription": "You can change your ad preferences at any time.",
+  "adsEnabled": "Personalized ads enabled",
+  "adsDisabled": "Personalized ads disabled",
+  "learnMore": "Learn more about how we use your data"
+}

--- a/i18n/pl.ts
+++ b/i18n/pl.ts
@@ -6,6 +6,7 @@ import onboarding from "@/i18n/pl/onboarding.json";
 import gamification from "@/i18n/pl/gamification.json";
 import errors from "@/i18n/pl/errors.json";
 import notifications from "@/i18n/pl/notifications.json";
+import consent from "@/i18n/pl/consent.json";
 
 export default {
   translation,
@@ -16,4 +17,5 @@ export default {
   gamification,
   errors,
   notifications,
+  consent,
 };

--- a/i18n/pl/consent.json
+++ b/i18n/pl/consent.json
@@ -1,0 +1,8 @@
+{
+  "privacySettings": "Ustawienia prywatnosci",
+  "manageConsent": "Zarzadzaj preferencjami reklam",
+  "consentDescription": "Mozesz zmienic swoje preferencje reklamowe w dowolnym momencie.",
+  "adsEnabled": "Spersonalizowane reklamy wlaczone",
+  "adsDisabled": "Spersonalizowane reklamy wylaczone",
+  "learnMore": "Dowiedz sie wiecej o tym, jak wykorzystujemy Twoje dane"
+}

--- a/services/consentService.ts
+++ b/services/consentService.ts
@@ -1,0 +1,159 @@
+import {
+  AdsConsent,
+  AdsConsentStatus,
+  AdsConsentInfo,
+  AdsConsentPrivacyOptionsRequirementStatus,
+} from "react-native-google-mobile-ads";
+import { logError, logInfo } from "@/utils/errorLogging";
+
+export type ConsentInfoResult = {
+  status: AdsConsentStatus;
+  canRequestAds: boolean;
+  isConsentFormAvailable: boolean;
+  privacyOptionsRequired: boolean;
+};
+
+/**
+ * Request consent info update from UMP SDK
+ * This checks if consent is required and what the current status is
+ */
+export async function requestConsentInfo(): Promise<ConsentInfoResult> {
+  try {
+    logInfo("Requesting consent info update", {
+      operation: "requestConsentInfo",
+      component: "ConsentService",
+    });
+
+    const consentInfo: AdsConsentInfo = await AdsConsent.requestInfoUpdate();
+
+    logInfo("Consent info received", {
+      operation: "requestConsentInfo",
+      component: "ConsentService",
+      data: {
+        status: consentInfo.status,
+        canRequestAds: consentInfo.canRequestAds,
+        isConsentFormAvailable: consentInfo.isConsentFormAvailable,
+      },
+    });
+
+    return {
+      status: consentInfo.status,
+      canRequestAds: consentInfo.canRequestAds,
+      isConsentFormAvailable: consentInfo.isConsentFormAvailable,
+      privacyOptionsRequired:
+        consentInfo.privacyOptionsRequirementStatus ===
+        AdsConsentPrivacyOptionsRequirementStatus.REQUIRED,
+    };
+  } catch (error) {
+    logError(error, {
+      operation: "requestConsentInfo",
+      component: "ConsentService",
+    });
+    throw error;
+  }
+}
+
+/**
+ * Show consent form if required
+ * Returns the consent info after form is dismissed
+ */
+export async function loadAndShowConsentFormIfRequired(): Promise<ConsentInfoResult> {
+  try {
+    logInfo("Showing consent form if required", {
+      operation: "loadAndShowConsentFormIfRequired",
+      component: "ConsentService",
+    });
+
+    const consentInfo: AdsConsentInfo =
+      await AdsConsent.loadAndShowConsentFormIfRequired();
+
+    logInfo("Consent form completed", {
+      operation: "loadAndShowConsentFormIfRequired",
+      component: "ConsentService",
+      data: {
+        status: consentInfo.status,
+        canRequestAds: consentInfo.canRequestAds,
+      },
+    });
+
+    return {
+      status: consentInfo.status,
+      canRequestAds: consentInfo.canRequestAds,
+      isConsentFormAvailable: consentInfo.isConsentFormAvailable,
+      privacyOptionsRequired:
+        consentInfo.privacyOptionsRequirementStatus ===
+        AdsConsentPrivacyOptionsRequirementStatus.REQUIRED,
+    };
+  } catch (error) {
+    logError(error, {
+      operation: "loadAndShowConsentFormIfRequired",
+      component: "ConsentService",
+    });
+    throw error;
+  }
+}
+
+/**
+ * Show privacy options form to let user change consent
+ * Only available if privacyOptionsRequired is true
+ */
+export async function showPrivacyOptionsForm(): Promise<ConsentInfoResult> {
+  try {
+    logInfo("Showing privacy options form", {
+      operation: "showPrivacyOptionsForm",
+      component: "ConsentService",
+    });
+
+    const consentInfo: AdsConsentInfo =
+      await AdsConsent.showPrivacyOptionsForm();
+
+    logInfo("Privacy options form completed", {
+      operation: "showPrivacyOptionsForm",
+      component: "ConsentService",
+      data: {
+        status: consentInfo.status,
+        canRequestAds: consentInfo.canRequestAds,
+      },
+    });
+
+    return {
+      status: consentInfo.status,
+      canRequestAds: consentInfo.canRequestAds,
+      isConsentFormAvailable: consentInfo.isConsentFormAvailable,
+      privacyOptionsRequired:
+        consentInfo.privacyOptionsRequirementStatus ===
+        AdsConsentPrivacyOptionsRequirementStatus.REQUIRED,
+    };
+  } catch (error) {
+    logError(error, {
+      operation: "showPrivacyOptionsForm",
+      component: "ConsentService",
+    });
+    throw error;
+  }
+}
+
+/**
+ * Reset consent info (for testing purposes)
+ */
+export function resetConsent(): void {
+  try {
+    logInfo("Resetting consent info", {
+      operation: "resetConsent",
+      component: "ConsentService",
+    });
+
+    AdsConsent.reset();
+
+    logInfo("Consent info reset successfully", {
+      operation: "resetConsent",
+      component: "ConsentService",
+    });
+  } catch (error) {
+    logError(error, {
+      operation: "resetConsent",
+      component: "ConsentService",
+    });
+    throw error;
+  }
+}

--- a/stores/consent.ts
+++ b/stores/consent.ts
@@ -1,0 +1,169 @@
+import { create } from "zustand";
+import mobileAds from "react-native-google-mobile-ads";
+import { AdsConsentStatus } from "react-native-google-mobile-ads";
+import {
+  requestConsentInfo,
+  loadAndShowConsentFormIfRequired,
+  showPrivacyOptionsForm,
+} from "@/services/consentService";
+import { logError, logInfo } from "@/utils/errorLogging";
+import {
+  ConsentInitializationStatus,
+  initialConsentState,
+} from "@/constants/consent";
+
+type ConsentState = {
+  status: AdsConsentStatus | null;
+  canRequestAds: boolean;
+  isInitialized: boolean;
+  initializationStatus: ConsentInitializationStatus;
+  isMobileAdsInitialized: boolean;
+  privacyOptionsRequired: boolean;
+};
+
+type ConsentActions = {
+  initializeConsent: () => Promise<void>;
+  showPrivacyOptions: () => Promise<void>;
+  reset: () => void;
+};
+
+export const useConsentStore = create<ConsentState & ConsentActions>(
+  (set, get) => ({
+    ...initialConsentState,
+
+    initializeConsent: async () => {
+      const currentStatus = get().initializationStatus;
+
+      // Prevent re-initialization
+      if (
+        currentStatus === ConsentInitializationStatus.IN_PROGRESS ||
+        currentStatus === ConsentInitializationStatus.COMPLETED
+      ) {
+        logInfo("Consent initialization already in progress or completed", {
+          operation: "initializeConsent",
+          component: "ConsentStore",
+          data: { currentStatus },
+        });
+        return;
+      }
+
+      set({ initializationStatus: ConsentInitializationStatus.IN_PROGRESS });
+
+      try {
+        logInfo("Starting consent initialization", {
+          operation: "initializeConsent",
+          component: "ConsentStore",
+        });
+
+        // Step 1: Request consent info update
+        await requestConsentInfo();
+
+        // Step 2: Show consent form if required (for EU users who haven't consented)
+        const consentResult = await loadAndShowConsentFormIfRequired();
+
+        set({
+          status: consentResult.status,
+          canRequestAds: consentResult.canRequestAds,
+          privacyOptionsRequired: consentResult.privacyOptionsRequired,
+          isInitialized: true,
+        });
+
+        logInfo("Consent status determined", {
+          operation: "initializeConsent",
+          component: "ConsentStore",
+          data: {
+            status: consentResult.status,
+            canRequestAds: consentResult.canRequestAds,
+            privacyOptionsRequired: consentResult.privacyOptionsRequired,
+          },
+        });
+
+        // Step 3: Initialize Mobile Ads SDK if we can request ads
+        if (consentResult.canRequestAds) {
+          logInfo("Initializing Mobile Ads SDK", {
+            operation: "initializeConsent",
+            component: "ConsentStore",
+          });
+
+          await mobileAds().initialize();
+
+          set({ isMobileAdsInitialized: true });
+
+          logInfo("Mobile Ads SDK initialized successfully", {
+            operation: "initializeConsent",
+            component: "ConsentStore",
+          });
+        } else {
+          logInfo("Skipping Mobile Ads initialization - cannot request ads", {
+            operation: "initializeConsent",
+            component: "ConsentStore",
+          });
+        }
+
+        set({ initializationStatus: ConsentInitializationStatus.COMPLETED });
+
+        logInfo("Consent initialization completed", {
+          operation: "initializeConsent",
+          component: "ConsentStore",
+        });
+      } catch (error) {
+        logError(error, {
+          operation: "initializeConsent",
+          component: "ConsentStore",
+        });
+
+        set({
+          initializationStatus: ConsentInitializationStatus.FAILED,
+          isInitialized: true,
+          canRequestAds: false,
+        });
+      }
+    },
+
+    showPrivacyOptions: async () => {
+      try {
+        logInfo("Showing privacy options", {
+          operation: "showPrivacyOptions",
+          component: "ConsentStore",
+        });
+
+        const result = await showPrivacyOptionsForm();
+
+        set({
+          status: result.status,
+          canRequestAds: result.canRequestAds,
+          privacyOptionsRequired: result.privacyOptionsRequired,
+        });
+
+        // If user changed consent to allow ads and SDK not initialized
+        if (result.canRequestAds && !get().isMobileAdsInitialized) {
+          logInfo("Initializing Mobile Ads SDK after consent change", {
+            operation: "showPrivacyOptions",
+            component: "ConsentStore",
+          });
+
+          await mobileAds().initialize();
+          set({ isMobileAdsInitialized: true });
+        }
+
+        logInfo("Privacy options completed", {
+          operation: "showPrivacyOptions",
+          component: "ConsentStore",
+          data: {
+            status: result.status,
+            canRequestAds: result.canRequestAds,
+          },
+        });
+      } catch (error) {
+        logError(error, {
+          operation: "showPrivacyOptions",
+          component: "ConsentStore",
+        });
+      }
+    },
+
+    reset: () => {
+      set(initialConsentState);
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- Implement Google UMP SDK for GDPR-compliant ad consent management
- Add consent store and service to handle consent flow
- Update Banner component to respect user consent preferences
- Add Privacy Settings button in setup menu for EU users to modify consent

## Test plan
- [ ] Test with EU VPN - consent dialog should appear on first launch
- [ ] Test without EU VPN - no consent dialog should appear
- [ ] Verify ads only show when consent is granted
- [ ] Tap Privacy Settings in setup menu → Google privacy form opens
- [ ] Change consent → app respects new setting (ads appear/disappear)
- [ ] Verify iOS NSUserTrackingUsageDescription appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)