### PR TITLE
ci: fix workflow triggers to match actual branch names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, development ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, development ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The CI workflow (`.github/workflows/ci.yml`) triggered on `main`/`develop`, but this repository uses `master`/`development`. As a result the workflow **never ran** — GitHub reports 0 runs for `ci.yml`. Lint, tests and coverage were not enforced on any push or PR.

This points the `push` and `pull_request` triggers at the real branch names so the pipeline runs again.

```diff
  push:
-   branches: [ main, develop ]
+   branches: [ master, development ]
  pull_request:
-   branches: [ main, develop ]
+   branches: [ master, development ]
```

## Verification

Ran the pipeline steps locally against this branch:

- `npm run lint` — 0 errors (10 non-blocking warnings)
- `npm test` — **257 tests passed**, 13 suites

So enabling the workflow should not immediately turn it red.

## Notes

This is the first of the follow-ups surfaced during the repo review. Still open for later: `master` is stale (v1.3.4) vs `development` (v1.5.3), and there are several merged feature branches worth pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Sd8bfhPkzPEBZJadGP5WU)_