### PR TITLE
style: complete ocean/water theme migration (#84–88)

### DIFF
--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -69,7 +69,7 @@ export const colors = {
     900: "#262568",
     950: "#1a1844",
   },
-  orange: {
+  steel: {
     50: "#f0f4fa",
     100: "#dce4f2",
     200: "#b8c8e3",

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -118,7 +118,7 @@ export async function setupNotificationChannel(): Promise<void> {
         description: i18n.t("channelDescription", { ns: "notifications" }),
         importance: Notifications.AndroidImportance.HIGH,
         vibrationPattern: [0, 250, 250, 250],
-        lightColor: "#3b82f6",
+        lightColor: "#2680eb",
       });
     } catch (error) {
       logError(error, {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,7 +71,7 @@ module.exports = {
           900: "#262568",
           950: "#1a1844",
         },
-        orange: {
+        steel: {
           50: "#f0f4fa",
           100: "#dce4f2",
           200: "#b8c8e3",

--- a/utils/pdfExport.ts
+++ b/utils/pdfExport.ts
@@ -32,7 +32,7 @@ function generateReportHTML(data: ReportData): string {
   const chartBars = stats.dailyData
     .map((day: DailyStats) => {
       const height = Math.min((day.percentage / 100) * 150, 150);
-      const color = day.percentage >= 100 ? '#10b981' : '#3b82f6';
+      const color = day.percentage >= 100 ? '#10b981' : '#2680eb';
       return `
         <div style="display: inline-block; margin: 0 4px; vertical-align: bottom;">
           <div style="width: 20px; height: ${height}px; background-color: ${color}; border-radius: 2px;"></div>
@@ -55,8 +55,8 @@ function generateReportHTML(data: ReportData): string {
             color: #1f2937;
           }
           h1 {
-            color: #1e40af;
-            border-bottom: 3px solid #3b82f6;
+            color: #0a2a62;
+            border-bottom: 3px solid #2680eb;
             padding-bottom: 10px;
             margin-bottom: 30px;
           }
@@ -69,7 +69,7 @@ function generateReportHTML(data: ReportData): string {
             margin-bottom: 40px;
           }
           .info {
-            color: #6b7280;
+            color: #64707e;
             font-size: 14px;
             margin: 5px 0;
           }
@@ -80,7 +80,7 @@ function generateReportHTML(data: ReportData): string {
             margin: 30px 0;
           }
           .stat-card {
-            border: 2px solid #e5e7eb;
+            border: 2px solid #e2e6ec;
             border-radius: 8px;
             padding: 20px;
             background-color: #f9fafb;
@@ -88,11 +88,11 @@ function generateReportHTML(data: ReportData): string {
           .stat-value {
             font-size: 32px;
             font-weight: bold;
-            color: #1e40af;
+            color: #0a2a62;
             margin-bottom: 5px;
           }
           .stat-label {
-            color: #6b7280;
+            color: #64707e;
             font-size: 14px;
           }
           .chart-container {
@@ -112,9 +112,9 @@ function generateReportHTML(data: ReportData): string {
           .footer {
             margin-top: 50px;
             padding-top: 20px;
-            border-top: 2px solid #e5e7eb;
+            border-top: 2px solid #e2e6ec;
             text-align: center;
-            color: #9ca3af;
+            color: #828d9a;
             font-size: 12px;
           }
         </style>

--- a/widgets/android/src/res/drawable-night/widget_background.xml
+++ b/widgets/android/src/res/drawable-night/widget_background.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:startColor="#0F172A"
-        android:endColor="#1E3A5F"
+        android:startColor="#0A2A62"
+        android:endColor="#061940"
         android:angle="135"
         android:type="linear" />
     <corners android:radius="16dp" />

--- a/widgets/android/src/res/drawable/widget_background.xml
+++ b/widgets/android/src/res/drawable/widget_background.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:startColor="#DBEAFE"
-        android:endColor="#93C5FD"
+        android:startColor="#D8ECFE"
+        android:endColor="#7EB8F7"
         android:angle="135"
         android:type="linear" />
     <corners android:radius="16dp" />

--- a/widgets/android/src/res/values-night/colors.xml
+++ b/widgets/android/src/res/values-night/colors.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="widget_background">#1F2937</color>
-    <color name="widget_button_bg">#3B82F6</color>
+    <color name="widget_background">#0A2A62</color>
+    <color name="widget_button_bg">#2680EB</color>
     <color name="widget_button_text">#FFFFFF</color>
-    <color name="widget_progress_bg">#1A3050</color>
-    <color name="widget_progress_fg">#60A5FA</color>
-    <color name="widget_accent">#60A5FA</color>
-    <color name="widget_text_primary">#E0EAFF</color>
-    <color name="widget_text_secondary">#94A3C8</color>
+    <color name="widget_progress_bg">#0E3D88</color>
+    <color name="widget_progress_fg">#4D9BF0</color>
+    <color name="widget_accent">#4D9BF0</color>
+    <color name="widget_text_primary">#D8ECFE</color>
+    <color name="widget_text_secondary">#A5B0CF</color>
     <color name="widget_streak">#FB923C</color>
 </resources>


### PR DESCRIPTION
## Summary

Finishes the color-palette migration started in PR #83 by updating the spots that were missed. Closes the follow-up debt tracked in issues #84–88.

| Issue | File(s) | Change |
| --- | --- | --- |
| #84 | `widgets/android/src/res/values-night/colors.xml` | Widget **night-mode** colors aligned to the new palette: `widget_button_bg` → `#2680EB`, `widget_accent`/`widget_progress_fg` → `#4D9BF0`, background → deep-ocean `#0A2A62`, `widget_progress_bg` → `#0E3D88`, text → `#D8ECFE`/`#A5B0CF` |
| #85 | `widgets/.../drawable/widget_background.xml`, `widgets/.../drawable-night/widget_background.xml` | Gradient backgrounds: day `#DBEAFE`→`#93C5FD` becomes `#D8ECFE`→`#7EB8F7` (blue-100/300); night `#0F172A`→`#1E3A5F` becomes `#0A2A62`→`#061940` (blue-900/950) |
| #86 | `services/notificationService.ts` | Notification LED `lightColor` `#3b82f6` → `#2680eb` (blue-500) |
| #87 | `utils/pdfExport.ts` | Hardcoded HTML colors remapped: `#3b82f6`→`#2680eb`, `#1e40af`→`#0a2a62`, `#6b7280`→`#64707e`, `#e5e7eb`→`#e2e6ec`, `#9ca3af`→`#828d9a` |
| #88 | `constants/colors.ts`, `tailwind.config.js` | Renamed the misleading `orange` palette (which now holds blue/steel shades `#5a7eb5`–`#101d3a`) to **`steel`** |

## Notes / decisions

- **#88 name** — chose `steel` because the values are a muted steel-blue, matching the actual colors (the issue's own criterion). Verified there are **no references** to `orange` / `colors.orange` / `orange-*` classes anywhere in components or tests, so no other files needed updating.
- **#87 scope** — applied exactly the five mappings listed in the issue. Left `#10b981` (the "goal met" green on the chart) and the neutral grays `#f9fafb`/`#1f2937`/`#374151` untouched, as they weren't in the mapping list and serve a distinct role.
- **#84 streak** — left `widget_streak` (`#FB923C`) as-is; it's an intentional warm accent, independent of the blue migration.

## Test plan

- [ ] Widgets render with consistent colors in both light and dark mode
- [ ] Notification LED shows the new blue
- [ ] Exported PDF uses the new palette
- [ ] `steel` palette resolves in Tailwind classes and `colors.steel` in TS

> ℹ️ `node_modules` was not present in the build container, so `tsc`/`jest`/`lint` were not run locally. Changes are color-value swaps plus a reference-free key rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh6FKRU9ck38SkVFQ3CNRt)_